### PR TITLE
Fix CI build configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
 plugins {
-    alias(libs.plugins.android.application)
+    id("com.android.application")
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.kotlin.kapt)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.android.application) apply false
+    id("com.android.application") version libs.versions.applicationPlugin apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.ktlint)


### PR DESCRIPTION
Need to directly declare an application plugin to make it visible to the AppCenter build system. Because version catalog declaration does not work before project synchronization (https://developer.android.com/build/migrate-to-catalogs#migrate-plugins)