### PR TITLE
Add code coverage reporting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,12 @@ jobs:
 
       - name: Run Unit Tests
         run: ./gradlew testDebugUnitTest
+
+      - name: Generate test coverage report
+        run: ./gradlew jacocoTestReport
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: app/build/reports/jacoco/jacocoTestReportDebug/jacocoTestReportDebug.xml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # Template
 ![test workflow](https://github.com/SoftTeco/AndroidAppTemplate/actions/workflows/test.yml/badge.svg)
+[![codecov](https://codecov.io/gh/SoftTeco/AndroidAppTemplate/graph/badge.svg)](https://codecov.io/gh/SoftTeco/AndroidAppTemplate)
 ![lint workflow](https://github.com/SoftTeco/AndroidAppTemplate/actions/workflows/lint.yml/badge.svg)
 
 Sample application to demonstrate usage of Jetpack Compose, Kotlin Flow, Android Hilt, etc.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.devtools.ksp)
     alias(libs.plugins.android.junit5)
+    jacoco
 }
 
 android {
@@ -131,5 +132,16 @@ tasks.withType<Test> {
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
         events("started", "skipped", "passed", "failed")
         showStandardStreams = true
+    }
+    configure<JacocoTaskExtension> {
+        isEnabled = true
+        isIncludeNoLocationClasses = false
+    }
+}
+
+tasks.register("jacocoTestReport", JacocoReport::class) {
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
     }
 }


### PR DESCRIPTION
## Summary
- Add step to GitHub Actions test workflow for uploading code coverage reports to codecov.io.

## Reasons
- Enhance the test workflow by including code coverage analysis and reporting.
- Ensure that code coverage metrics are tracked and monitored for better visibility into test coverage.

## References
- closes #74