### PR TITLE
Add signature screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,6 +111,9 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
+    implementation(libs.signature.pad.compose)
+    implementation(libs.io.coil.kt.coil.svg)
+    implementation(libs.io.coil.kt.coil.compose)
 
     implementation(libs.preferences.data.store)
 

--- a/app/src/main/kotlin/com/softteco/template/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/com/softteco/template/navigation/AppNavHost.kt
@@ -64,8 +64,8 @@ fun NavGraphBuilder.bottomBarGraph(
             HomeScreen(
                 modifier = modifier,
                 onLoginClicked = { navController.navigate(Screen.Login.route) },
-                onSignatureClicked = { },
                 onBleClicked = { navController.navigate(Screen.Bluetooth.route) },
+                onSignatureClicked = { navController.navigate(Screen.Signature.route) },
             )
         }
         composable(Screen.Profile.route) {

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/home/HomeScreen.kt
@@ -139,7 +139,6 @@ sealed class HomeCards(
         descriptionId = R.string.signature_description,
         drawableRes = R.drawable.baseline_design_services_24,
         onClick = onClick,
-        enabled = false,
     )
 
     class BleCard(onClick: () -> Unit) : HomeCards(

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/signature/SignatureScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/signature/SignatureScreen.kt
@@ -1,53 +1,173 @@
 package com.softteco.template.ui.feature.signature
 
+import android.graphics.Bitmap
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.softteco.template.ui.theme.AppTheme
-import com.softteco.template.ui.theme.Dimens
+import coil.compose.AsyncImage
+import coil.decode.SvgDecoder
+import coil.request.ImageRequest
+import com.softteco.template.R
+import com.softteco.template.ui.components.CustomTopAppBar
+import com.softteco.template.ui.theme.Dimens.PaddingDefault
+import se.warting.signaturepad.SignaturePadAdapter
+import se.warting.signaturepad.SignaturePadView
 
 @Composable
 fun SignatureScreen(
     onBackClicked: () -> Unit,
     viewModel: SignatureViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.state.collectAsState()
+    val signatureFilePath by viewModel.signatureFilePath.collectAsState()
     ScreenContent(
-        state = state,
+        signatureFilePath = signatureFilePath,
         onBackClicked = onBackClicked,
+        saveAsJpg = { viewModel.saveSignatureAsJPG(it) },
+        saveSignatureAsSvg = { viewModel.saveSignatureAsSvg(it) },
+        onDeleteSignatureClicked = { viewModel.deleteSignature(it) }
     )
 }
 
 @Composable
 private fun ScreenContent(
-    state: SignatureViewModel.State,
+    signatureFilePath: String,
     onBackClicked: () -> Unit,
-    modifier: Modifier = Modifier
+    saveAsJpg: (Bitmap) -> Unit,
+    saveSignatureAsSvg: (String) -> Unit,
+    onDeleteSignatureClicked: (String) -> Unit
 ) {
-    Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall)) {
-            Text(state.data)
-            Button(onClick = onBackClicked) {
-                Text("Back")
+    Column(Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+        CustomTopAppBar(
+            onBackClicked = onBackClicked,
+            showBackIcon = true,
+            title = stringResource(id = R.string.signature),
+        )
+        SignatureDrawPanel(
+            modifier = Modifier.weight(1f),
+            saveAsJpg = saveAsJpg,
+            saveSignatureAsSvg = saveSignatureAsSvg,
+        )
+        SignatureViewPanel(
+            modifier = Modifier.weight(1f),
+            signatureFilePath = signatureFilePath,
+            onDeleteSignatureClicked = onDeleteSignatureClicked,
+        )
+    }
+}
+
+@Composable
+private fun SignatureDrawPanel(
+    saveAsJpg: (Bitmap) -> Unit,
+    saveSignatureAsSvg: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var signaturePadAdapter: SignaturePadAdapter? = null
+    Column(
+        modifier = modifier
+            .padding(PaddingDefault)
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(id = R.string.sign_here),
+            modifier = Modifier.padding(top = PaddingDefault)
+        )
+        SignaturePadView(
+            modifier = Modifier
+                .weight(1f)
+                .padding(PaddingDefault)
+                .background(MaterialTheme.colorScheme.background),
+            onReady = {
+                signaturePadAdapter = it
             }
+        )
+        SignaturePadControls(
+            saveAsJpg = { signaturePadAdapter?.getSignatureBitmap()?.let { saveAsJpg(it) } },
+            saveSignatureAsSvg = {
+                saveSignatureAsSvg(
+                    signaturePadAdapter?.getSignatureSvg() ?: ""
+                )
+            },
+            clear = { signaturePadAdapter?.clear() },
+            modifier = Modifier.padding(top = PaddingDefault)
+        )
+    }
+}
+
+@Composable
+private fun SignaturePadControls(
+    saveAsJpg: () -> Unit,
+    saveSignatureAsSvg: () -> Unit,
+    clear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        Button(onClick = clear) {
+            Text(stringResource(id = R.string.clear))
+        }
+        Button(onClick = saveSignatureAsSvg) {
+            Text(stringResource(id = R.string.save_as_svg))
+        }
+        Button(onClick = saveAsJpg) {
+            Text(stringResource(id = R.string.save_as_jpg))
         }
     }
 }
 
-@Preview
 @Composable
-private fun Preview() {
-    AppTheme {
-        ScreenContent(SignatureViewModel.State(), onBackClicked = {})
+private fun SignatureViewPanel(
+    signatureFilePath: String,
+    onDeleteSignatureClicked: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(PaddingDefault)
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        if (signatureFilePath.isNotEmpty()) {
+            Column {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(signatureFilePath)
+                        .decoderFactory(SvgDecoder.Factory())
+                        .build(),
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(PaddingDefault),
+                    contentScale = ContentScale.Inside,
+                    contentDescription = stringResource(id = R.string.signature)
+                )
+                Button(onClick = { onDeleteSignatureClicked(signatureFilePath) }) {
+                    Text(stringResource(id = R.string.delete_file))
+                }
+            }
+        } else {
+            Text(
+                text = stringResource(id = R.string.empty_here),
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/signature/SignatureViewModel.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/signature/SignatureViewModel.kt
@@ -1,18 +1,68 @@
 package com.softteco.template.ui.feature.signature
 
-import androidx.compose.runtime.Immutable
+import android.graphics.Bitmap
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.softteco.template.utils.SIGNATURE_NAME
+import com.softteco.template.utils.SignatureStorageManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
+private const val JPG = ".jpg"
+private const val SVG = ".svg"
+
 @HiltViewModel
-class SignatureViewModel @Inject constructor() : ViewModel() {
+class SignatureViewModel @Inject constructor(
+    private val storeManager: SignatureStorageManager,
+) : ViewModel() {
 
-    val state = MutableStateFlow(State())
+    private val _signatureFilePath = MutableStateFlow("")
+    val signatureFilePath = _signatureFilePath.asStateFlow()
 
-    @Immutable
-    data class State(
-        val data: String = "Signature",
-    )
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            _signatureFilePath.value = storeManager.getSignatureFilePath()
+        }
+    }
+
+    fun saveSignatureAsJPG(bitmap: Bitmap) = viewModelScope.launch(Dispatchers.IO) {
+        cleanCurrentSignature()
+        val newFileName = buildSignatureName(extension = JPG)
+        val filePath = storeManager.saveSignatureAsJPG(bitmap, newFileName)
+        _signatureFilePath.value = filePath
+    }
+
+    private fun buildSignatureName(extension: String): String =
+        SIGNATURE_NAME + System.currentTimeMillis() + extension
+
+    fun saveSignatureAsSvg(svg: String) = viewModelScope.launch(Dispatchers.IO) {
+        cleanCurrentSignature()
+        val newFileName = buildSignatureName(extension = SVG)
+        val filePath = storeManager.saveSignatureAsSvg(svg, newFileName)
+        _signatureFilePath.value = filePath
+    }
+
+    private suspend fun cleanCurrentSignature() {
+        val signaturePath = signatureFilePath.first()
+        if (signaturePath.isNotEmpty()) deleteFile(signaturePath)
+    }
+
+    fun deleteSignature(filePath: String) = viewModelScope.launch {
+        deleteFile(filePath)
+    }
+
+    private suspend fun deleteFile(filePath: String) {
+        withContext(Dispatchers.IO) {
+            if (filePath.isNotEmpty()) {
+                storeManager.deleteFile(filePath)
+                _signatureFilePath.value = ""
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/com/softteco/template/utils/SignatureStorageManager.kt
+++ b/app/src/main/kotlin/com/softteco/template/utils/SignatureStorageManager.kt
@@ -1,0 +1,58 @@
+package com.softteco.template.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+
+const val SIGNATURE_NAME = "Signature"
+
+class SignatureStorageManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    fun saveSignatureAsJPG(bitmap: Bitmap, fileName: String): String {
+        val outputFile = File(context.cacheDir, fileName)
+        bitmapToFile(outputFile, bitmap)
+        return outputFile.path
+    }
+
+    fun saveSignatureAsSvg(svg: String, fileName: String): String {
+        val outputFile = File(context.cacheDir, fileName)
+        svg.byteInputStream().use { input ->
+            FileOutputStream(outputFile).use { output ->
+                input.copyTo(output)
+            }
+        }
+        return outputFile.path
+    }
+
+    private fun bitmapToFile(
+        file: File,
+        bitmap: Bitmap,
+        quality: Int = 100
+    ): File {
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
+        FileOutputStream(file).use { fileOutPutStream ->
+            byteArrayOutputStream.use {
+                val bitMapData = it.toByteArray()
+                fileOutPutStream.write(bitMapData)
+            }
+        }
+        return file
+    }
+
+    fun getSignatureFilePath(): String {
+        val files = context.cacheDir.listFiles()
+        return files?.firstOrNull { it.name.startsWith(SIGNATURE_NAME) }?.path ?: ""
+    }
+
+    fun deleteFile(path: String) {
+        val file = File(path)
+        if (file.exists()) file.delete()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,15 @@
     <string name="signature">Signature</string>
     <string name="signature_description">Graphic signature</string>
 
+    <!-- Signature screen -->
+    <string name="clear">Clear</string>
+    <string name="save_as_svg">Save as SVG</string>
+    <string name="save_as_jpg">Save as JPG</string>
+    <string name="sign_here">Sign here:</string>
+    <string name="result">Result:</string>
+    <string name="empty_here">Empty here</string>
+    <string name="delete_file">Delete file</string>
+
     <string name="forgot_password">Forgot password</string>
     <string name="restore_password">Restore password</string>
     <string name="check_email">Check your email</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,8 @@ room = "2.5.2"
 composeMaterialDialog = "0.9.0"
 iconCompose = "1.5.1"
 dataStore = "1.0.0"
+coil = "2.2.2"
+signaturePad = "0.1.2"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "ktx" }
@@ -74,6 +76,9 @@ androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref =
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 androidx-compose-icons = { module = "androidx.compose.material:material-icons-extended", version.ref = "iconCompose" }
 preferences-data-store = { module = "androidx.datastore:datastore-preferences", version.ref = "dataStore" }
+io-coil-kt-coil-svg = { module = "io.coil-kt:coil-svg" , version.ref = "coil" }
+io-coil-kt-coil-compose = { module = "io.coil-kt:coil-compose" , version.ref = "coil" }
+signature-pad-compose = { module = "se.warting.signature:signature-pad", version.ref = "signaturePad" }
 
 
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary

Added Signature screen:
<img width="405" alt="image" src="https://github.com/SoftTeco/AndroidAppTemplate/assets/5811516/797bf5ce-d17f-4943-ae18-014c616ea350">


## Reasons

The signature screen was absent. 
The signature screen allows create and keep a user's signature. 

## References

closes #28 