### PR TITLE
Add unit tests for the Login screen

### DIFF
--- a/app/src/test/kotlin/com/softteco/template/ui/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/login/LoginViewModelTest.kt
@@ -27,7 +27,7 @@ class LoginViewModelTest : BaseTest() {
     private lateinit var viewModel: LoginViewModel
 
     @Test
-    fun `when login button is enabled and valid credentials success state is emitted`() = runTest {
+    fun `when valid credentials and login button is enabled then success state is emitted`() = runTest {
         val credentials = CredentialsDto(email = "test@email.com", password = "password")
         coEvery { repository.login(credentials) } returns Result.Success(Unit)
         viewModel = LoginViewModel(repository)

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/login/LoginViewModelTest.kt
@@ -5,6 +5,8 @@ import com.softteco.template.BaseTest
 import com.softteco.template.data.base.error.Result
 import com.softteco.template.data.profile.ProfileRepository
 import com.softteco.template.data.profile.dto.CredentialsDto
+import com.softteco.template.ui.feature.EmailFieldState
+import com.softteco.template.ui.feature.PasswordFieldState
 import com.softteco.template.utils.MainDispatcherExtension
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
@@ -46,21 +48,21 @@ class LoginViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `when login button isn't enabled and invalid password then error state is emitted`() =
+    fun `when invalid password then login button isn't enabled and password field error is shown`() =
         runTest {
             viewModel = LoginViewModel(repository)
             viewModel.state.test {
                 awaitItem().onEmailChanged("test@email.com")
-                awaitItem().onPasswordChanged("")
                 delay(1.seconds)
                 expectMostRecentItem().run {
+                    fieldStatePassword shouldBe PasswordFieldState.Empty
                     isLoginBtnEnabled shouldBe false
                 }
             }
         }
 
     @Test
-    fun `when login button isn't enabled and invalid email then error state is emitted`() =
+    fun `when invalid email then login button isn't enabled and email field error is shown`() =
         runTest {
             viewModel = LoginViewModel(repository)
             viewModel.state.test {
@@ -68,17 +70,20 @@ class LoginViewModelTest : BaseTest() {
                 awaitItem().onPasswordChanged("password")
                 delay(1.seconds)
                 expectMostRecentItem().run {
+                    fieldStateEmail shouldBe EmailFieldState.Error
                     isLoginBtnEnabled shouldBe false
                 }
             }
         }
 
     @Test
-    fun `when login button isn't enabled with both empty email and password then error state is emitted`() =
+    fun `when both empty email and password then button isn't enabled and email, password fields error are shown`() =
         runTest {
             viewModel = LoginViewModel(repository)
             viewModel.state.test {
                 awaitItem().run {
+                    fieldStateEmail shouldBe EmailFieldState.Empty
+                    fieldStatePassword shouldBe PasswordFieldState.Empty
                     isLoginBtnEnabled shouldBe false
                 }
             }
@@ -88,7 +93,7 @@ class LoginViewModelTest : BaseTest() {
     fun `when login button clicked and request in progress then loading is shown`() = runTest {
         val credentials = CredentialsDto(email = "test@email.com", password = "password")
         coEvery { repository.login(credentials) } coAnswers {
-            delay(2000)
+            delay(1.seconds)
             Result.Success(Unit)
         }
         viewModel = LoginViewModel(repository)

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/login/LoginViewModelTest.kt
@@ -1,0 +1,97 @@
+package com.softteco.template.ui.feature.login
+
+import app.cash.turbine.test
+import com.softteco.template.BaseTest
+import com.softteco.template.data.base.error.Result
+import com.softteco.template.data.profile.ProfileRepository
+import com.softteco.template.utils.MainDispatcherExtension
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MainDispatcherExtension::class)
+class LoginViewModelTest : BaseTest() {
+
+    @RelaxedMockK
+    private lateinit var repository: ProfileRepository
+
+    private lateinit var viewModel: LoginViewModel
+
+    @Test
+    fun `when login is clicked with valid email and password, success state is shown`() = runTest {
+        coEvery { repository.login(any()) } returns Result.Success(Unit)
+        viewModel = LoginViewModel(repository)
+        viewModel.state.value.onEmailChanged("test@example.com")
+        viewModel.state.value.onPasswordChanged("password")
+
+        viewModel.state.value.onLoginClicked()
+
+        viewModel.state.test {
+            awaitItem().run {
+                loginState shouldBe LoginViewModel.LoginState.Success
+                snackBar.show shouldBe true
+            }
+        }
+
+        coVerify(exactly = 1) { repository.login(any()) }
+    }
+
+    @Test
+    fun `when login is clicked with invalid email, error state is shown`() = runTest {
+        viewModel = LoginViewModel(repository)
+        viewModel.state.value.onEmailChanged("invalid-email")
+        viewModel.state.value.onPasswordChanged("password")
+
+        viewModel.state.value.onLoginClicked()
+
+        viewModel.state.test {
+            awaitItem().run {
+                loginState shouldBe LoginViewModel.LoginState.Default
+                snackBar.show shouldBe true
+            }
+        }
+
+        coVerify(exactly = 0) { repository.login(any()) }
+    }
+
+    @Test
+    fun `when login is clicked with empty password, error state is shown`() = runTest {
+        viewModel = LoginViewModel(repository)
+        viewModel.state.value.onEmailChanged("test@example.com")
+        viewModel.state.value.onPasswordChanged("")
+
+        viewModel.state.value.onLoginClicked()
+
+        viewModel.state.test {
+            awaitItem().run {
+                loginState shouldBe LoginViewModel.LoginState.Default
+                snackBar.show shouldBe true
+            }
+        }
+
+        coVerify(exactly = 0) { repository.login(any()) }
+    }
+
+    @Test
+    fun `when login is clicked with both empty email and password, error state is shown`() =
+        runTest {
+            viewModel = LoginViewModel(repository)
+            viewModel.state.value.onEmailChanged("")
+            viewModel.state.value.onPasswordChanged("")
+
+            viewModel.state.value.onLoginClicked()
+
+            viewModel.state.test {
+                awaitItem().run {
+                    loginState shouldBe LoginViewModel.LoginState.Default
+                    snackBar.show shouldBe true
+                }
+            }
+
+            coVerify(exactly = 0) { repository.login(any()) }
+        }
+}


### PR DESCRIPTION
## Summary

Added tests for Login screen.

## Reasons

The tests for Login screen were absent.
To verify that a  system functions as intended, to catch errors, ensure code reliability, and support ongoing development by providing a safety net for changes.

## References

closes #92