### PR TITLE
Remove multi-line input support

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,3 +6,5 @@ coverage:
     patch:
       default:
         informational: true
+github_checks:
+    annotations: false

--- a/app/src/main/kotlin/com/softteco/template/ui/components/EmailField.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/components/EmailField.kt
@@ -3,6 +3,7 @@ package com.softteco.template.ui.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -22,8 +23,7 @@ fun EmailField(
     modifier: Modifier = Modifier,
 ) {
     Column {
-        val isError =
-            fieldStateEmail is EmailFieldState.Empty || fieldStateEmail is EmailFieldState.Error
+        val isError = fieldStateEmail is EmailFieldState.Error
         OutlinedTextField(
             value = emailValue,
             onValueChange = { newValue ->
@@ -35,17 +35,15 @@ fun EmailField(
             },
             isError = isError,
             supportingText = {
-                if (isError) {
-                    Text(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = when (fieldStateEmail) {
-                            is EmailFieldState.Empty -> stringResource(R.string.required)
-                            is EmailFieldState.Error -> stringResource(R.string.email_not_valid)
-                            else -> ""
-                        },
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = when (fieldStateEmail) {
+                        is EmailFieldState.Empty -> stringResource(R.string.required)
+                        is EmailFieldState.Error -> stringResource(R.string.email_not_valid)
+                        else -> ""
+                    },
+                    color = if (isError) MaterialTheme.colorScheme.error else LocalContentColor.current
+                )
             },
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Next,

--- a/app/src/main/kotlin/com/softteco/template/ui/components/EmailField.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/components/EmailField.kt
@@ -2,12 +2,15 @@ package com.softteco.template.ui.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import com.softteco.template.R
 import com.softteco.template.ui.feature.EmailFieldState
 
@@ -44,6 +47,11 @@ fun EmailField(
                     )
                 }
             },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next,
+                keyboardType = KeyboardType.Email,
+            ),
+            singleLine = true,
         )
     }
 }

--- a/app/src/main/kotlin/com/softteco/template/ui/components/PasswordField.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/components/PasswordField.kt
@@ -4,10 +4,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -17,6 +15,7 @@ import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -25,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
 import com.softteco.template.R
 import com.softteco.template.ui.feature.PasswordFieldState
 import com.softteco.template.ui.theme.Dimens
@@ -44,12 +45,10 @@ fun PasswordField(
     onPasswordChanged: (String) -> Unit,
     fieldStatePassword: PasswordFieldState,
     modifier: Modifier = Modifier,
-    isPasswordHasMinimum: Boolean? = null,
-    isPasswordHasUpperCase: Boolean? = null,
 ) {
     Column {
         var passwordVisibility by remember { mutableStateOf(true) }
-        val isError = fieldStatePassword is PasswordFieldState.Empty
+        val isError = fieldStatePassword is PasswordFieldState.Error
         val keyboardController = LocalSoftwareKeyboardController.current
         OutlinedTextField(
             value = passwordValue,
@@ -61,18 +60,7 @@ fun PasswordField(
                 Text(text = stringResource(id = R.string.password))
             },
             isError = isError,
-            supportingText = {
-                if (isError) {
-                    Text(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = when (fieldStatePassword) {
-                            is PasswordFieldState.Empty -> stringResource(R.string.required)
-                            else -> ""
-                        },
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
-            },
+            supportingText = { SupportingText(passwordState = fieldStatePassword) },
             trailingIcon = {
                 IconButton(onClick = {
                     passwordVisibility = !passwordVisibility
@@ -84,11 +72,15 @@ fun PasswordField(
                             Icons.Filled.Visibility
                         },
                         contentDescription = stringResource(id = R.string.visibility),
-                        tint = MaterialTheme.colorScheme.primary
+                        tint = if (isError) MaterialTheme.colorScheme.error else LocalContentColor.current
                     )
                 }
             },
-            visualTransformation = if (passwordVisibility) PasswordVisualTransformation() else VisualTransformation.None,
+            visualTransformation = if (passwordVisibility) {
+                PasswordVisualTransformation()
+            } else {
+                VisualTransformation.None
+            },
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Done,
                 keyboardType = KeyboardType.Password,
@@ -97,17 +89,28 @@ fun PasswordField(
             singleLine = true,
         )
     }
-    if (isPasswordHasMinimum != null && isPasswordHasUpperCase != null) {
-        Spacer(modifier = Modifier.height(Dimens.PaddingDefault))
-        Column(verticalArrangement = Arrangement.spacedBy(Dimens.PaddingDefault)) {
-            ConditionRow(
-                condition = stringResource(R.string.registration_password_condition1),
-                check = isPasswordHasMinimum
-            )
-            ConditionRow(
-                condition = stringResource(R.string.registration_password_condition2),
-                check = isPasswordHasUpperCase
-            )
+}
+
+@Composable
+private fun SupportingText(passwordState: PasswordFieldState, modifier: Modifier = Modifier) {
+    Column(modifier.height(48.dp)) {
+        when (passwordState) {
+            PasswordFieldState.Empty -> Text(stringResource(R.string.required))
+            is PasswordFieldState.Error -> {
+                Column(verticalArrangement = Arrangement.spacedBy(Dimens.PaddingExtraSmall)) {
+                    ConditionRow(
+                        condition = stringResource(R.string.registration_password_condition1),
+                        check = passwordState.isRightLength
+                    )
+                    ConditionRow(
+                        condition = stringResource(R.string.registration_password_condition2),
+                        check = passwordState.isUppercase
+                    )
+                }
+            }
+
+            PasswordFieldState.Success -> { /* NOOP */
+            }
         }
     }
 }
@@ -116,26 +119,22 @@ fun PasswordField(
 private fun ConditionRow(
     condition: String,
     check: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val color by animateColorAsState(
-        targetValue = if (check) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.error,
+        targetValue = if (check) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.error,
         label = "ColorAnimation"
     )
 
-    val icon = if (check) {
-        Icons.Rounded.Check
-    } else {
-        Icons.Rounded.Close
-    }
+    val icon = if (check) Icons.Rounded.Check else Icons.Rounded.Close
 
-    Row(modifier = modifier) {
+    Row(modifier = modifier, verticalAlignment = Alignment.Top) {
         Icon(
             imageVector = icon,
+            contentDescription = stringResource(id = R.string.visibility),
+            Modifier.size(18.dp),
             tint = color,
-            contentDescription = stringResource(id = R.string.visibility)
         )
-        Spacer(modifier = Modifier.width(Dimens.PaddingDefault))
         Text(
             text = condition,
             color = color

--- a/app/src/main/kotlin/com/softteco/template/ui/components/PasswordField.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/components/PasswordField.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -23,14 +25,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.softteco.template.R
 import com.softteco.template.ui.feature.PasswordFieldState
 import com.softteco.template.ui.theme.Dimens
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PasswordField(
     passwordValue: String,
@@ -43,6 +50,7 @@ fun PasswordField(
     Column {
         var passwordVisibility by remember { mutableStateOf(true) }
         val isError = fieldStatePassword is PasswordFieldState.Empty
+        val keyboardController = LocalSoftwareKeyboardController.current
         OutlinedTextField(
             value = passwordValue,
             onValueChange = { newValue ->
@@ -80,7 +88,13 @@ fun PasswordField(
                     )
                 }
             },
-            visualTransformation = if (passwordVisibility) PasswordVisualTransformation() else VisualTransformation.None
+            visualTransformation = if (passwordVisibility) PasswordVisualTransformation() else VisualTransformation.None,
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Done,
+                keyboardType = KeyboardType.Password,
+            ),
+            keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+            singleLine = true,
         )
     }
     if (isPasswordHasMinimum != null && isPasswordHasUpperCase != null) {

--- a/app/src/main/kotlin/com/softteco/template/ui/components/PrimaryButton.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/components/PrimaryButton.kt
@@ -16,11 +16,13 @@ fun PrimaryButton(
     buttonText: String,
     loading: Boolean,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     Button(
         onClick = { if (!loading) onClick() },
         shape = MaterialTheme.shapes.large,
+        enabled = enabled,
         modifier = modifier.fillMaxWidth()
     ) {
         if (loading) {

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/ValidateFields.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/ValidateFields.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.milliseconds
 
-const val INPUT_DELAY: Long = 600
+private const val INPUT_DELAY: Long = 600
 
 object ValidateFields {
 

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/ValidateFields.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/ValidateFields.kt
@@ -1,6 +1,18 @@
 package com.softteco.template.ui.feature
 
 import com.softteco.template.Constants
+import com.softteco.template.ui.feature.ValidateFields.isEmailCorrect
+import com.softteco.template.ui.feature.ValidateFields.isHasCapitalizedLetter
+import com.softteco.template.ui.feature.ValidateFields.isHasMinimum
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+
+const val INPUT_DELAY: Long = 600
 
 object ValidateFields {
 
@@ -24,15 +36,41 @@ sealed class EmailFieldState {
     object Error : EmailFieldState()
 }
 
-sealed class SimpleFieldState {
-    object Success : SimpleFieldState()
-    object Empty : SimpleFieldState()
-    object Waiting : SimpleFieldState()
-}
-
 sealed class PasswordFieldState {
     object Success : PasswordFieldState()
     object Empty : PasswordFieldState()
-    object Waiting : PasswordFieldState()
-    object Error : PasswordFieldState()
+    class Error(val isRightLength: Boolean, val isUppercase: Boolean) : PasswordFieldState()
+}
+
+@OptIn(FlowPreview::class)
+internal fun validateEmail(
+    fieldValue: MutableStateFlow<String>,
+    fieldState: MutableStateFlow<EmailFieldState>,
+    coroutineScope: CoroutineScope,
+) {
+    coroutineScope.launch {
+        fieldValue
+            .onEach { fieldState.value = EmailFieldState.Waiting }
+            .debounce(INPUT_DELAY.milliseconds).collect { value ->
+                fieldState.value = when {
+                    value.isEmailCorrect() -> EmailFieldState.Success
+                    value.isEmpty() -> EmailFieldState.Empty
+                    else -> EmailFieldState.Error
+                }
+            }
+    }
+}
+
+internal fun validatePassword(password: String): PasswordFieldState {
+    return when {
+        password.isBlank() -> PasswordFieldState.Empty
+        !password.isHasMinimum() || !password.isHasCapitalizedLetter() -> {
+            PasswordFieldState.Error(
+                isRightLength = password.isHasMinimum(),
+                isUppercase = password.isHasCapitalizedLetter()
+            )
+        }
+
+        else -> PasswordFieldState.Success
+    }
 }

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/forgotPassword/ForgotPasswordScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/forgotPassword/ForgotPasswordScreen.kt
@@ -1,10 +1,12 @@
 package com.softteco.template.ui.feature.forgotPassword
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -60,7 +62,9 @@ private fun ScreenContent(
         onDismissSnackbar = state.dismissSnackBar,
     ) {
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(Dimens.PaddingExtraLarge),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -87,6 +91,7 @@ private fun ScreenContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = Dimens.PaddingLarge),
+                    enabled = state.isResetBtnEnabled,
                     onClick = { state.onRestorePasswordClicked() }
                 )
             }

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/login/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.softteco.template.ui.feature.login
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -82,7 +83,9 @@ private fun ScreenContent(
         onDismissSnackbar = state.dismissSnackBar,
     ) {
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(Dimens.PaddingExtraLarge),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -112,17 +115,14 @@ private fun ScreenContent(
                 PrimaryButton(
                     buttonText = stringResource(id = R.string.login),
                     loading = state.loginState == LoginViewModel.LoginState.Loading,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = Dimens.PaddingLarge),
-                    onClick = { state.onLoginClicked() }
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = state.isLoginBtnEnabled,
+                    onClick = { state.onLoginClicked() },
                 )
                 SecondaryButton(
                     title = stringResource(id = R.string.sign_up),
                     loading = false,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = Dimens.PaddingSmall),
+                    modifier = Modifier.fillMaxWidth(),
                     onClick = { onSignUpClicked() }
                 )
                 Spacer(modifier = Modifier.height(Dimens.PaddingDefault))

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordScreen.kt
@@ -1,10 +1,11 @@
 package com.softteco.template.ui.feature.resetPassword
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,6 +22,7 @@ import com.softteco.template.ui.components.PrimaryButton
 import com.softteco.template.ui.components.TextSnackbarContainer
 import com.softteco.template.ui.theme.AppTheme
 import com.softteco.template.ui.theme.Dimens
+import com.softteco.template.ui.theme.Dimens.PaddingExtraLarge
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 
@@ -58,9 +60,9 @@ private fun ScreenContent(
     ) {
         Column(
             modifier = Modifier
-                .padding(Dimens.PaddingExtraLarge)
+                .background(MaterialTheme.colorScheme.background)
+                .padding(PaddingExtraLarge)
                 .fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(Dimens.PaddingExtraLarge),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(text = stringResource(id = R.string.enter_new_password))
@@ -68,16 +70,17 @@ private fun ScreenContent(
                 passwordValue = state.passwordValue,
                 onPasswordChanged = state.onPasswordChanged,
                 fieldStatePassword = state.fieldStatePassword,
-                isPasswordHasMinimum = state.isPasswordHasMinimum,
-                isPasswordHasUpperCase = state.isPasswordHasUpperCase,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .padding(top = PaddingExtraLarge)
+                    .fillMaxWidth()
             )
             PrimaryButton(
                 buttonText = stringResource(id = R.string.reset_password),
                 loading = state.resetPasswordState == ResetPasswordViewModel.ResetPasswordState.Loading,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = Dimens.PaddingLarge),
+                    .padding(top = Dimens.PaddingDefault),
+                enabled = state.isResetBtnEnabled,
                 onClick = { state.onResetPasswordClicked() }
             )
         }

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/signUp/SignUpScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/signUp/SignUpScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -17,6 +18,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.softteco.template.R
@@ -132,7 +135,12 @@ private fun UserNameField(
             label = {
                 Text(text = stringResource(id = R.string.user_name))
             },
-            isError = state.fieldStateUserName is SimpleFieldState.Empty
+            isError = state.fieldStateUserName is SimpleFieldState.Empty,
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next,
+                keyboardType = KeyboardType.Ascii,
+            ),
+            singleLine = true,
         )
         val errorText = when (state.fieldStateUserName) {
             is SimpleFieldState.Empty -> stringResource(R.string.required)

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/signUp/SignUpScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/signUp/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package com.softteco.template.ui.feature.signUp
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -28,9 +29,10 @@ import com.softteco.template.ui.components.EmailField
 import com.softteco.template.ui.components.PasswordField
 import com.softteco.template.ui.components.PrimaryButton
 import com.softteco.template.ui.components.TextSnackbarContainer
-import com.softteco.template.ui.feature.SimpleFieldState
+import com.softteco.template.ui.feature.PasswordFieldState
 import com.softteco.template.ui.theme.AppTheme
 import com.softteco.template.ui.theme.Dimens
+import com.softteco.template.ui.theme.Dimens.PaddingDefault
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 
@@ -72,7 +74,9 @@ private fun ScreenContent(
         onDismissSnackbar = state.dismissSnackBar,
     ) {
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(Dimens.PaddingExtraLarge),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -97,22 +101,25 @@ private fun ScreenContent(
                     emailValue = state.emailValue,
                     onEmailChanged = state.onEmailChanged,
                     fieldStateEmail = state.fieldStateEmail,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .padding(top = PaddingDefault)
+                        .fillMaxWidth()
                 )
                 PasswordField(
                     passwordValue = state.passwordValue,
                     onPasswordChanged = state.onPasswordChanged,
                     fieldStatePassword = state.fieldStatePassword,
-                    isPasswordHasMinimum = state.isPasswordHasMinimum,
-                    isPasswordHasUpperCase = state.isPasswordHasUpperCase,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .padding(top = PaddingDefault)
+                        .fillMaxWidth()
                 )
                 PrimaryButton(
                     buttonText = stringResource(id = R.string.sign_up),
                     loading = state.registrationState == SignUpViewModel.SignupState.Loading,
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = Dimens.PaddingLarge),
+                        .padding(top = PaddingDefault)
+                        .fillMaxWidth(),
+                    enabled = state.isSignupBtnEnabled,
                     onClick = { state.onRegisterClicked() }
                 )
             }
@@ -135,18 +142,15 @@ private fun UserNameField(
             label = {
                 Text(text = stringResource(id = R.string.user_name))
             },
-            isError = state.fieldStateUserName is SimpleFieldState.Empty,
+            supportingText = {
+                Text(if (state.userNameValue.isBlank()) stringResource(R.string.required) else "")
+            },
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Next,
                 keyboardType = KeyboardType.Ascii,
             ),
             singleLine = true,
         )
-        val errorText = when (state.fieldStateUserName) {
-            is SimpleFieldState.Empty -> stringResource(R.string.required)
-            else -> ""
-        }
-        Text(errorText, color = MaterialTheme.colorScheme.error)
     }
 }
 
@@ -155,7 +159,7 @@ private fun UserNameField(
 private fun Preview() {
     AppTheme {
         ScreenContent(
-            SignUpViewModel.State(),
+            SignUpViewModel.State(fieldStatePassword = PasswordFieldState.Error(true, false)),
             onBackClicked = {},
         )
     }


### PR DESCRIPTION
## Summary

- Removed the ability to input multiline in text fields;
- Added focus switching and suitable keyboard options;
- Fixed input validation issues;
- Improved state handling for input fields.


## Reasons

- Removing the ability to input multiline in text fields improves user experience by providing a more straightforward input experience.
- Fixing input validation issues ensures that the input data meets the required criteria before being processed.
- Improving state handling for input fields ensures that the input fields are updated correctly based on user interactions.

## References

- closes #91 