### PR TITLE
Add unit tests for the Sign up screen

### DIFF
--- a/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
@@ -11,11 +11,11 @@ import io.kotest.matchers.types.shouldBeTypeOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.RelaxedMockK
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.Duration.Companion.seconds
 
 @ExtendWith(MainDispatcherExtension::class)
 class SignUpViewModelTest : BaseTest() {

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
@@ -27,7 +27,7 @@ class SignUpViewModelTest : BaseTest() {
     private lateinit var viewModel: SignUpViewModel
 
     @Test
-    fun `when sign-up button is enabled and valid credentials then success state is emitted`() =
+    fun `when valid credentials and sign-up button is enabled then success state is emitted`() =
         runTest {
             val createUserDto = CreateUserDto(
                 username = "testuser",

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
@@ -1,0 +1,164 @@
+package com.softteco.template.ui.feature.signUp
+
+import app.cash.turbine.test
+import com.softteco.template.BaseTest
+import com.softteco.template.data.base.error.Result
+import com.softteco.template.data.profile.ProfileRepository
+import com.softteco.template.data.profile.dto.CreateUserDto
+import com.softteco.template.utils.MainDispatcherExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MainDispatcherExtension::class)
+class SignUpViewModelTest : BaseTest() {
+
+    @RelaxedMockK
+    private lateinit var repository: ProfileRepository
+    private lateinit var viewModel: SignUpViewModel
+
+    @Test
+    fun `when sign-up button is enabled and valid credentials then success state is emitted`() =
+        runTest {
+            val createUserDto = CreateUserDto(
+                username = "testuser",
+                email = "test@email.com",
+                password = "passwordTest"
+            )
+            coEvery { repository.registration(createUserDto) } returns Result.Success("")
+            viewModel = SignUpViewModel(repository)
+
+            viewModel.state.test {
+                awaitItem().onUserNameChanged("testuser")
+                awaitItem().onEmailChanged("test@email.com")
+                awaitItem().onPasswordChanged("passwordTest")
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isSignupBtnEnabled shouldBe true
+                    onRegisterClicked()
+                }
+
+                awaitItem().run {
+                    registrationState.shouldBeTypeOf<SignUpViewModel.SignupState.Success>()
+                    snackBar.show shouldBe true
+                }
+            }
+
+            coVerify(exactly = 1) { repository.registration(createUserDto) }
+        }
+
+    @Test
+    fun `when sign-up button isn't enabled and invalid email then error state is emitted`() =
+        runTest {
+            viewModel = SignUpViewModel(repository)
+            viewModel.state.test {
+                awaitItem().onEmailChanged("invalid@email")
+                awaitItem().onUserNameChanged("testuser")
+                awaitItem().onPasswordChanged("passwordTest")
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isSignupBtnEnabled shouldBe false
+                }
+            }
+        }
+
+    @Test
+    fun `when sign-up button isn't enabled and invalid password then error state is emitted`() =
+        runTest {
+            viewModel = SignUpViewModel(repository)
+            viewModel.state.test {
+                awaitItem().onPasswordChanged("password")
+                awaitItem().onUserNameChanged("testuser")
+                awaitItem().onEmailChanged("test@email.com")
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isSignupBtnEnabled shouldBe false
+                }
+            }
+        }
+
+    @Test
+    fun `when sign-up button isn't enabled and invalid password has not enough symbols then error state is emitted`() =
+        runTest {
+            viewModel = SignUpViewModel(repository)
+            viewModel.state.test {
+                awaitItem().onPasswordChanged("pswD")
+                awaitItem().onUserNameChanged("testuser")
+                awaitItem().onEmailChanged("test@email.com")
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isSignupBtnEnabled shouldBe false
+                }
+            }
+        }
+
+    @Test
+    fun `when sign-up button isn't enabled and invalid username then error state is emitted`() =
+        runTest {
+            viewModel = SignUpViewModel(repository)
+            viewModel.state.test {
+                awaitItem().onPasswordChanged("passwordTest")
+                awaitItem().onEmailChanged("test@email.com")
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isSignupBtnEnabled shouldBe false
+                }
+            }
+        }
+
+    @Test
+    fun `when sign-up button isn't enabled and empty username, email, and password then error state is emitted`() =
+        runTest {
+            viewModel = SignUpViewModel(repository)
+            viewModel.state.test {
+                awaitItem().run {
+                    isSignupBtnEnabled shouldBe false
+                }
+            }
+        }
+
+    @Test
+    fun `when registration button clicked and request in progress then loading is shown`() =
+        runTest {
+            val createUserDto = CreateUserDto(
+                username = "testuser",
+                email = "test@email.com",
+                password = "passwordTest"
+            )
+            coEvery { repository.registration(createUserDto) } coAnswers {
+                delay(2000)
+                Result.Success("")
+            }
+            viewModel = SignUpViewModel(repository)
+
+            viewModel.state.test {
+                awaitItem().onUserNameChanged("testuser")
+                awaitItem().onEmailChanged("test@email.com")
+                awaitItem().onPasswordChanged("passwordTest")
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isSignupBtnEnabled shouldBe true
+                    onRegisterClicked()
+                }
+
+                awaitItem().run {
+                    registrationState.shouldBeTypeOf<SignUpViewModel.SignupState.Loading>()
+                }
+            }
+
+            coVerify(exactly = 1) { repository.registration(createUserDto) }
+        }
+}

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
@@ -5,6 +5,8 @@ import com.softteco.template.BaseTest
 import com.softteco.template.data.base.error.Result
 import com.softteco.template.data.profile.ProfileRepository
 import com.softteco.template.data.profile.dto.CreateUserDto
+import com.softteco.template.ui.feature.EmailFieldState
+import com.softteco.template.ui.feature.PasswordFieldState
 import com.softteco.template.utils.MainDispatcherExtension
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
@@ -56,7 +58,7 @@ class SignUpViewModelTest : BaseTest() {
         }
 
     @Test
-    fun `when sign-up button isn't enabled and invalid email then error state is emitted`() =
+    fun `when invalid email then email field error is shown and sign-up button isn't enabled`() =
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
@@ -67,12 +69,13 @@ class SignUpViewModelTest : BaseTest() {
 
                 expectMostRecentItem().run {
                     isSignupBtnEnabled shouldBe false
+                    fieldStateEmail shouldBe EmailFieldState.Error
                 }
             }
         }
 
     @Test
-    fun `when sign-up button isn't enabled and invalid password then error state is emitted`() =
+    fun `when password hasn't capital letter then password field error is shown and sign-up button isn't enabled`() =
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
@@ -82,13 +85,15 @@ class SignUpViewModelTest : BaseTest() {
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
+                    fieldStatePassword.shouldBeTypeOf<PasswordFieldState.Error>()
+                    (fieldStatePassword as PasswordFieldState.Error).isUppercase shouldBe false
                     isSignupBtnEnabled shouldBe false
                 }
             }
         }
 
     @Test
-    fun `when sign-up button isn't enabled and field password has not enough symbols then error state is emitted`() =
+    fun `when password hasn't enough symbols then password field error is shown and sign-up button isn't enabled`() =
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
@@ -98,13 +103,15 @@ class SignUpViewModelTest : BaseTest() {
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
+                    fieldStatePassword.shouldBeTypeOf<PasswordFieldState.Error>()
+                    (fieldStatePassword as PasswordFieldState.Error).isRightLength shouldBe false
                     isSignupBtnEnabled shouldBe false
                 }
             }
         }
 
     @Test
-    fun `when sign-up button isn't enabled and empty username then error state is emitted`() =
+    fun `when empty username then sign-up button isn't enabled`() =
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
@@ -119,11 +126,13 @@ class SignUpViewModelTest : BaseTest() {
         }
 
     @Test
-    fun `when sign-up button isn't enabled and empty username, email, and password then error state is emitted`() =
+    fun `when empty username, email, password then password, email fields error are shown and button isn't enabled`() =
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
                 awaitItem().run {
+                    fieldStatePassword shouldBe PasswordFieldState.Empty
+                    fieldStateEmail shouldBe EmailFieldState.Empty
                     isSignupBtnEnabled shouldBe false
                 }
             }

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
@@ -88,7 +88,7 @@ class SignUpViewModelTest : BaseTest() {
         }
 
     @Test
-    fun `when sign-up button isn't enabled and invalid password has not enough symbols then error state is emitted`() =
+    fun `when sign-up button isn't enabled and field password has not enough symbols then error state is emitted`() =
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
@@ -104,7 +104,7 @@ class SignUpViewModelTest : BaseTest() {
         }
 
     @Test
-    fun `when sign-up button isn't enabled and invalid username then error state is emitted`() =
+    fun `when sign-up button isn't enabled and empty username then error state is emitted`() =
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
@@ -138,7 +138,7 @@ class SignUpViewModelTest : BaseTest() {
                 password = "passwordTest"
             )
             coEvery { repository.registration(createUserDto) } coAnswers {
-                delay(2000)
+                delay(1.seconds)
                 Result.Success("")
             }
             viewModel = SignUpViewModel(repository)


### PR DESCRIPTION
## Summary

Added tests for Sign up screen.

## Reasons

The tests for Sign up screen were absent.
To verify that a system functions as intended, to catch errors, ensure code reliability, and support ongoing development by providing a safety net for changes.

## References

closes https://github.com/SoftTeco/AndroidAppTemplate/pull/95