### PR TITLE
Add unit tests for the Reset password screen 

### DIFF
--- a/app/src/test/kotlin/com/softteco/template/ui/feature/forgotPassword/ForgotPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/forgotPassword/ForgotPasswordViewModelTest.kt
@@ -18,24 +18,26 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.time.Duration.Companion.seconds
 
+private const val EMAIL = "test@email.com"
+private const val INVALID_EMAIL = "invalid@email"
+
 @ExtendWith(MainDispatcherExtension::class)
 class ForgotPasswordViewModelTest : BaseTest() {
 
     @RelaxedMockK
     private lateinit var repository: ProfileRepository
     private lateinit var viewModel: ForgotPasswordViewModel
-    private val email = "test@email.com"
 
     @Test
     fun `when valid email and reset password button is enabled then success state is emitted`() =
         runTest {
-            coEvery { repository.resetPassword(ResetPasswordDto(email)) } returns Result.Success(
+            coEvery { repository.resetPassword(ResetPasswordDto(EMAIL)) } returns Result.Success(
                 Unit
             )
             viewModel = ForgotPasswordViewModel(repository)
 
             viewModel.state.test {
-                awaitItem().onEmailChanged(email)
+                awaitItem().onEmailChanged(EMAIL)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -49,7 +51,7 @@ class ForgotPasswordViewModelTest : BaseTest() {
                 }
             }
 
-            coVerify(exactly = 1) { repository.resetPassword(ResetPasswordDto(email)) }
+            coVerify(exactly = 1) { repository.resetPassword(ResetPasswordDto(EMAIL)) }
         }
 
     @Test
@@ -57,7 +59,7 @@ class ForgotPasswordViewModelTest : BaseTest() {
         runTest {
             viewModel = ForgotPasswordViewModel(repository)
             viewModel.state.test {
-                awaitItem().onEmailChanged("invalid@email")
+                awaitItem().onEmailChanged(INVALID_EMAIL)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -82,14 +84,14 @@ class ForgotPasswordViewModelTest : BaseTest() {
     @Test
     fun `when reset password button clicked and request in progress then loading is shown`() =
         runTest {
-            coEvery { repository.resetPassword(ResetPasswordDto(email)) } coAnswers {
+            coEvery { repository.resetPassword(ResetPasswordDto(EMAIL)) } coAnswers {
                 delay(1.seconds)
                 Result.Success(Unit)
             }
             viewModel = ForgotPasswordViewModel(repository)
 
             viewModel.state.test {
-                awaitItem().onEmailChanged(email)
+                awaitItem().onEmailChanged(EMAIL)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -102,6 +104,6 @@ class ForgotPasswordViewModelTest : BaseTest() {
                 }
             }
 
-            coVerify(exactly = 1) { repository.resetPassword(ResetPasswordDto(email)) }
+            coVerify(exactly = 1) { repository.resetPassword(ResetPasswordDto(EMAIL)) }
         }
 }

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordViewModelTest.kt
@@ -28,7 +28,7 @@ class ResetPasswordViewModelTest : BaseTest() {
     private lateinit var viewModel: ResetPasswordViewModel
 
     @Test
-    fun `when reset password button is enabled and valid password then success state is emitted`() =
+    fun `when valid password and reset password button is enabled then success state is emitted`() =
         runTest {
             val token = "testToken"
             val newPassword = "newPassword"

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordViewModelTest.kt
@@ -111,7 +111,7 @@ class ResetPasswordViewModelTest : BaseTest() {
                     NewPasswordDto(newPassword, newPassword)
                 )
             } coAnswers {
-                delay(2000)
+                delay(1.seconds)
                 Result.Success(Unit)
             }
             viewModel = ResetPasswordViewModel(

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordViewModelTest.kt
@@ -20,6 +20,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.time.Duration.Companion.seconds
 
+private const val TOKEN = "testToken"
+private const val NEW_PASSWORD = "newPassword"
+private const val NEW_PASSWORD_NOT_VALID_1 = "newpassword"
+private const val NEW_PASSWORD_NOT_VALID_2 = "neW"
+
 @ExtendWith(MainDispatcherExtension::class)
 class ResetPasswordViewModelTest : BaseTest() {
 
@@ -30,18 +35,16 @@ class ResetPasswordViewModelTest : BaseTest() {
     @Test
     fun `when valid password and reset password button is enabled then success state is emitted`() =
         runTest {
-            val token = "testToken"
-            val newPassword = "newPassword"
             coEvery {
-                repository.changePassword(token, NewPasswordDto(newPassword, newPassword))
+                repository.changePassword(TOKEN, NewPasswordDto(NEW_PASSWORD, NEW_PASSWORD))
             } returns Result.Success(Unit)
             val savedStateHandle = SavedStateHandle().apply {
-                set(AppNavHost.RESET_TOKEN_ARG, token)
+                set(AppNavHost.RESET_TOKEN_ARG, TOKEN)
             }
             viewModel = ResetPasswordViewModel(repository, savedStateHandle)
 
             viewModel.state.test {
-                awaitItem().onPasswordChanged(newPassword)
+                awaitItem().onPasswordChanged(NEW_PASSWORD)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -57,8 +60,8 @@ class ResetPasswordViewModelTest : BaseTest() {
 
             coVerify(exactly = 1) {
                 repository.changePassword(
-                    token,
-                    NewPasswordDto(newPassword, newPassword)
+                    TOKEN,
+                    NewPasswordDto(NEW_PASSWORD, NEW_PASSWORD)
                 )
             }
         }
@@ -66,16 +69,14 @@ class ResetPasswordViewModelTest : BaseTest() {
     @Test
     fun `when password hasn't capital letter then password field error is shown and button isn't enabled`() =
         runTest {
-            val token = "testToken"
-            val newPassword = "newpassword"
             viewModel = ResetPasswordViewModel(
                 repository,
                 SavedStateHandle().apply {
-                    set(AppNavHost.RESET_TOKEN_ARG, token)
+                    set(AppNavHost.RESET_TOKEN_ARG, TOKEN)
                 }
             )
             viewModel.state.test {
-                awaitItem().onPasswordChanged(newPassword)
+                awaitItem().onPasswordChanged(NEW_PASSWORD_NOT_VALID_1)
                 delay(1.seconds)
                 expectMostRecentItem().run {
                     fieldStatePassword.shouldBeTypeOf<PasswordFieldState.Error>()
@@ -88,16 +89,14 @@ class ResetPasswordViewModelTest : BaseTest() {
     @Test
     fun `when password hasn't enough letters then password field error is shown and button isn't enabled`() =
         runTest {
-            val token = "testToken"
-            val newPassword = "neW"
             viewModel = ResetPasswordViewModel(
                 repository,
                 SavedStateHandle().apply {
-                    set(AppNavHost.RESET_TOKEN_ARG, token)
+                    set(AppNavHost.RESET_TOKEN_ARG, TOKEN)
                 }
             )
             viewModel.state.test {
-                awaitItem().onPasswordChanged(newPassword)
+                awaitItem().onPasswordChanged(NEW_PASSWORD_NOT_VALID_2)
                 delay(1.seconds)
                 expectMostRecentItem().run {
                     fieldStatePassword.shouldBeTypeOf<PasswordFieldState.Error>()
@@ -110,11 +109,10 @@ class ResetPasswordViewModelTest : BaseTest() {
     @Test
     fun `when empty password then password field error is shown and button isn't enabled`() =
         runTest {
-            val token = "testToken"
             viewModel = ResetPasswordViewModel(
                 repository,
                 SavedStateHandle().apply {
-                    set(AppNavHost.RESET_TOKEN_ARG, token)
+                    set(AppNavHost.RESET_TOKEN_ARG, TOKEN)
                 }
             )
             viewModel.state.test {
@@ -128,12 +126,10 @@ class ResetPasswordViewModelTest : BaseTest() {
     @Test
     fun `when reset password button clicked and request in progress then loading is shown`() =
         runTest {
-            val token = "testToken"
-            val newPassword = "newPassword"
             coEvery {
                 repository.changePassword(
-                    token,
-                    NewPasswordDto(newPassword, newPassword)
+                    TOKEN,
+                    NewPasswordDto(NEW_PASSWORD, NEW_PASSWORD)
                 )
             } coAnswers {
                 delay(1.seconds)
@@ -142,12 +138,12 @@ class ResetPasswordViewModelTest : BaseTest() {
             viewModel = ResetPasswordViewModel(
                 repository,
                 SavedStateHandle().apply {
-                    set(AppNavHost.RESET_TOKEN_ARG, token)
+                    set(AppNavHost.RESET_TOKEN_ARG, TOKEN)
                 }
             )
 
             viewModel.state.test {
-                awaitItem().onPasswordChanged(newPassword)
+                awaitItem().onPasswordChanged(NEW_PASSWORD)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -162,8 +158,8 @@ class ResetPasswordViewModelTest : BaseTest() {
 
             coVerify(exactly = 1) {
                 repository.changePassword(
-                    token,
-                    NewPasswordDto(newPassword, newPassword)
+                    TOKEN,
+                    NewPasswordDto(NEW_PASSWORD, NEW_PASSWORD)
                 )
             }
         }

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/resetPassword/ResetPasswordViewModelTest.kt
@@ -1,0 +1,145 @@
+package com.softteco.template.ui.feature.resetPassword
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.softteco.template.BaseTest
+import com.softteco.template.data.base.error.Result
+import com.softteco.template.data.profile.ProfileRepository
+import com.softteco.template.data.profile.dto.NewPasswordDto
+import com.softteco.template.navigation.AppNavHost
+import com.softteco.template.utils.MainDispatcherExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.Duration.Companion.seconds
+
+@ExtendWith(MainDispatcherExtension::class)
+class ResetPasswordViewModelTest : BaseTest() {
+
+    @RelaxedMockK
+    private lateinit var repository: ProfileRepository
+    private lateinit var viewModel: ResetPasswordViewModel
+
+    @Test
+    fun `when reset password button is enabled and valid password then success state is emitted`() =
+        runTest {
+            val token = "testToken"
+            val newPassword = "newPassword"
+            coEvery {
+                repository.changePassword(token, NewPasswordDto(newPassword, newPassword))
+            } returns Result.Success(Unit)
+            val savedStateHandle = SavedStateHandle().apply {
+                set(AppNavHost.RESET_TOKEN_ARG, token)
+            }
+            viewModel = ResetPasswordViewModel(repository, savedStateHandle)
+
+            viewModel.state.test {
+                awaitItem().onPasswordChanged(newPassword)
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isResetBtnEnabled shouldBe true
+                    onResetPasswordClicked()
+                }
+
+                awaitItem().run {
+                    resetPasswordState.shouldBeTypeOf<ResetPasswordViewModel.ResetPasswordState.Success>()
+                    snackBar.show shouldBe true
+                }
+            }
+
+            coVerify(exactly = 1) {
+                repository.changePassword(
+                    token,
+                    NewPasswordDto(newPassword, newPassword)
+                )
+            }
+        }
+
+    @Test
+    fun `when reset password button isn't enabled and invalid password then error state is emitted`() =
+        runTest {
+            val token = "testToken"
+            val newPassword = "newpassword"
+            viewModel = ResetPasswordViewModel(
+                repository,
+                SavedStateHandle().apply {
+                    set(AppNavHost.RESET_TOKEN_ARG, token)
+                }
+            )
+            viewModel.state.test {
+                awaitItem().onPasswordChanged(newPassword)
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isResetBtnEnabled shouldBe false
+                }
+            }
+        }
+
+    @Test
+    fun `when reset password button isn't enabled and empty password then error state is emitted`() =
+        runTest {
+            val token = "testToken"
+            viewModel = ResetPasswordViewModel(
+                repository,
+                SavedStateHandle().apply {
+                    set(AppNavHost.RESET_TOKEN_ARG, token)
+                }
+            )
+            viewModel.state.test {
+                awaitItem().run {
+                    isResetBtnEnabled shouldBe false
+                }
+            }
+        }
+
+    @Test
+    fun `when reset password button clicked and request in progress then loading is shown`() =
+        runTest {
+            val token = "testToken"
+            val newPassword = "newPassword"
+            coEvery {
+                repository.changePassword(
+                    token,
+                    NewPasswordDto(newPassword, newPassword)
+                )
+            } coAnswers {
+                delay(2000)
+                Result.Success(Unit)
+            }
+            viewModel = ResetPasswordViewModel(
+                repository,
+                SavedStateHandle().apply {
+                    set(AppNavHost.RESET_TOKEN_ARG, token)
+                }
+            )
+
+            viewModel.state.test {
+                awaitItem().onPasswordChanged(newPassword)
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
+                    isResetBtnEnabled shouldBe true
+                    onResetPasswordClicked()
+                }
+
+                awaitItem().run {
+                    resetPasswordState.shouldBeTypeOf<ResetPasswordViewModel.ResetPasswordState.Loading>()
+                }
+            }
+
+            coVerify(exactly = 1) {
+                repository.changePassword(
+                    token,
+                    NewPasswordDto(newPassword, newPassword)
+                )
+            }
+        }
+}

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
@@ -19,6 +19,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.time.Duration.Companion.seconds
 
+private const val USERNAME = "testuser"
+private const val EMAIL = "test@email.com"
+private const val PASSWORD = "passwordTest"
+private const val INVALID_EMAIL = "invalid@email"
+private const val NEW_PASSWORD_NOT_VALID_1 = "newpassword"
+private const val NEW_PASSWORD_NOT_VALID_2 = "pswD"
+
 @ExtendWith(MainDispatcherExtension::class)
 class SignUpViewModelTest : BaseTest() {
 
@@ -30,17 +37,17 @@ class SignUpViewModelTest : BaseTest() {
     fun `when valid credentials and sign-up button is enabled then success state is emitted`() =
         runTest {
             val createUserDto = CreateUserDto(
-                username = "testuser",
-                email = "test@email.com",
-                password = "passwordTest"
+                username = USERNAME,
+                email = EMAIL,
+                password = PASSWORD
             )
             coEvery { repository.registration(createUserDto) } returns Result.Success("")
             viewModel = SignUpViewModel(repository)
 
             viewModel.state.test {
-                awaitItem().onUserNameChanged("testuser")
-                awaitItem().onEmailChanged("test@email.com")
-                awaitItem().onPasswordChanged("passwordTest")
+                awaitItem().onUserNameChanged(USERNAME)
+                awaitItem().onEmailChanged(EMAIL)
+                awaitItem().onPasswordChanged(PASSWORD)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -62,9 +69,9 @@ class SignUpViewModelTest : BaseTest() {
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
-                awaitItem().onEmailChanged("invalid@email")
-                awaitItem().onUserNameChanged("testuser")
-                awaitItem().onPasswordChanged("passwordTest")
+                awaitItem().onEmailChanged(INVALID_EMAIL)
+                awaitItem().onUserNameChanged(USERNAME)
+                awaitItem().onPasswordChanged(PASSWORD)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -79,9 +86,9 @@ class SignUpViewModelTest : BaseTest() {
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
-                awaitItem().onPasswordChanged("password")
-                awaitItem().onUserNameChanged("testuser")
-                awaitItem().onEmailChanged("test@email.com")
+                awaitItem().onPasswordChanged(NEW_PASSWORD_NOT_VALID_1)
+                awaitItem().onUserNameChanged(USERNAME)
+                awaitItem().onEmailChanged(EMAIL)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -97,9 +104,9 @@ class SignUpViewModelTest : BaseTest() {
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
-                awaitItem().onPasswordChanged("pswD")
-                awaitItem().onUserNameChanged("testuser")
-                awaitItem().onEmailChanged("test@email.com")
+                awaitItem().onPasswordChanged(NEW_PASSWORD_NOT_VALID_2)
+                awaitItem().onUserNameChanged(USERNAME)
+                awaitItem().onEmailChanged(EMAIL)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -115,8 +122,8 @@ class SignUpViewModelTest : BaseTest() {
         runTest {
             viewModel = SignUpViewModel(repository)
             viewModel.state.test {
-                awaitItem().onPasswordChanged("passwordTest")
-                awaitItem().onEmailChanged("test@email.com")
+                awaitItem().onPasswordChanged(PASSWORD)
+                awaitItem().onEmailChanged(EMAIL)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -142,9 +149,9 @@ class SignUpViewModelTest : BaseTest() {
     fun `when registration button clicked and request in progress then loading is shown`() =
         runTest {
             val createUserDto = CreateUserDto(
-                username = "testuser",
-                email = "test@email.com",
-                password = "passwordTest"
+                username = USERNAME,
+                email = EMAIL,
+                password = PASSWORD
             )
             coEvery { repository.registration(createUserDto) } coAnswers {
                 delay(1.seconds)
@@ -153,9 +160,9 @@ class SignUpViewModelTest : BaseTest() {
             viewModel = SignUpViewModel(repository)
 
             viewModel.state.test {
-                awaitItem().onUserNameChanged("testuser")
-                awaitItem().onEmailChanged("test@email.com")
-                awaitItem().onPasswordChanged("passwordTest")
+                awaitItem().onUserNameChanged(USERNAME)
+                awaitItem().onEmailChanged(EMAIL)
+                awaitItem().onPasswordChanged(PASSWORD)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {


### PR DESCRIPTION
## Summary

Added tests for the Reset password screen.

## Reasons

The tests for Reset password screen were absent.
To verify that a system functions as intended, to catch errors, ensure code reliability, and support ongoing development by providing a safety net for changes.

## References

closes https://github.com/SoftTeco/AndroidAppTemplate/pull/97