### PR TITLE
Restore unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,9 @@ android {
         debug {
             isDebuggable = true
             buildConfigField("String", "BASE_URL", baseUrl)
-            enableAndroidTestCoverage = true
+            // disabled because of unit tests errors,
+            // could be restored after running instrumentation tests on CI, and fixing unit tests errors
+            // enableAndroidTestCoverage = true
         }
     }
     compileOptions {


### PR DESCRIPTION
## Summary
Avoid crashing unit tests on CI.


## Reasons
Unit tests crash on CI because of enableAndroidTestCoverage = true.
enableAndroidTestCoverage = true is used for calculating coverage including Instrumented tests, but until we don't run them on CI, let's keep it disabled. Probably it will require updating AGP. 