### PR TITLE
Fix login unit test 

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/data/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/softteco/template/data/di/NetworkModule.kt
@@ -4,12 +4,14 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import com.softteco.template.BuildConfig
 import com.softteco.template.data.RestCountriesApi
 import com.softteco.template.data.TemplateApi
+import com.softteco.template.utils.AppDispatchers
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
@@ -65,4 +67,10 @@ object NetworkModule {
             .client(okHttpClient)
             .build()
     }
+
+    @Provides
+    @Singleton
+    fun provideAppDispatchers(): AppDispatchers = AppDispatchers(
+        io = Dispatchers.IO
+    )
 }

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/login/LoginViewModel.kt
@@ -10,9 +10,9 @@ import com.softteco.template.ui.components.SnackBarState
 import com.softteco.template.ui.feature.EmailFieldState
 import com.softteco.template.ui.feature.PasswordFieldState
 import com.softteco.template.ui.feature.validateEmail
+import com.softteco.template.utils.AppDispatchers
 import com.softteco.template.utils.handleApiError
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -23,6 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val repository: ProfileRepository,
+    private val appDispatchers: AppDispatchers
 ) : ViewModel() {
 
     private val loginState = MutableStateFlow<LoginState>(LoginState.Default)
@@ -64,7 +65,7 @@ class LoginViewModel @Inject constructor(
     )
 
     private fun onLogin() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(appDispatchers.io) {
             loginState.value = LoginState.Loading
 
             val credentials = CredentialsDto(

--- a/app/src/main/kotlin/com/softteco/template/utils/AppDispatchers.kt
+++ b/app/src/main/kotlin/com/softteco/template/utils/AppDispatchers.kt
@@ -1,0 +1,5 @@
+package com.softteco.template.utils
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+data class AppDispatchers(val io: CoroutineDispatcher)

--- a/app/src/test/kotlin/com/softteco/template/BaseTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/BaseTest.kt
@@ -1,8 +1,14 @@
 package com.softteco.template
 
+import com.softteco.template.utils.AppDispatchers
 import io.mockk.MockKAnnotations
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 open class BaseTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = UnconfinedTestDispatcher()
+    protected val appDispatchers = AppDispatchers(dispatcher)
     init {
         MockKAnnotations.init(this)
     }

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/login/LoginViewModelTest.kt
@@ -30,14 +30,12 @@ class LoginViewModelTest : BaseTest() {
     private lateinit var repository: ProfileRepository
     private lateinit var viewModel: LoginViewModel
 
-    // The test doesn't work because of using Dispatchers.IO in onLogin method  in LoginViewModel
-    // Need to investigate it and probably use a wrapper for Dispatchers to mock them in tests.
-/*    @Test
+    @Test
     fun `when valid credentials and login button is enabled then success state is emitted`() =
         runTest {
             val credentials = CredentialsDto(email = EMAIL, password = PASSWORD)
             coEvery { repository.login(credentials) } returns Result.Success(Unit)
-            viewModel = LoginViewModel(repository)
+            viewModel = LoginViewModel(repository, appDispatchers)
             viewModel.state.test {
                 awaitItem().onEmailChanged(EMAIL)
                 awaitItem().onPasswordChanged(PASSWORD)
@@ -49,12 +47,12 @@ class LoginViewModelTest : BaseTest() {
                 awaitItem().loginState.shouldBeTypeOf<LoginViewModel.LoginState.Success>()
             }
             coVerify(exactly = 1) { repository.login(credentials) }
-        }*/
+        }
 
     @Test
     fun `when invalid password then login button isn't enabled and password field error is shown`() =
         runTest {
-            viewModel = LoginViewModel(repository)
+            viewModel = LoginViewModel(repository, appDispatchers)
             viewModel.state.test {
                 awaitItem().onEmailChanged(EMAIL)
                 delay(1.seconds)
@@ -68,7 +66,7 @@ class LoginViewModelTest : BaseTest() {
     @Test
     fun `when invalid email then login button isn't enabled and email field error is shown`() =
         runTest {
-            viewModel = LoginViewModel(repository)
+            viewModel = LoginViewModel(repository, appDispatchers)
             viewModel.state.test {
                 awaitItem().onEmailChanged(INVALID_EMAIL)
                 awaitItem().onPasswordChanged(PASSWORD)
@@ -83,7 +81,7 @@ class LoginViewModelTest : BaseTest() {
     @Test
     fun `when both empty email and password then button isn't enabled and email, password fields error are shown`() =
         runTest {
-            viewModel = LoginViewModel(repository)
+            viewModel = LoginViewModel(repository, appDispatchers)
             viewModel.state.test {
                 awaitItem().run {
                     fieldStateEmail shouldBe EmailFieldState.Empty
@@ -100,7 +98,7 @@ class LoginViewModelTest : BaseTest() {
             delay(1.seconds)
             Result.Success(Unit)
         }
-        viewModel = LoginViewModel(repository)
+        viewModel = LoginViewModel(repository, appDispatchers)
         viewModel.state.test {
             awaitItem().onEmailChanged(EMAIL)
             awaitItem().onPasswordChanged(PASSWORD)


### PR DESCRIPTION
## Summary

Fixed Login screen's Unit tests

## Reasons
It failled after adding Dispatchers.IO in onLogin method in LoginViewModel.
It was necessary to investigate how to restore the test of onLogin using Dispatchers.IO.

## References

closes #123