### PR TITLE
Add Terms and Conditions tick on Sign Up screen

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/Constants.kt
+++ b/app/src/main/kotlin/com/softteco/template/Constants.kt
@@ -6,4 +6,5 @@ object Constants {
     const val PASSWORD_PATTERN_MIN = ".{6,}"
     const val CONTACT_EMAIL = "softteco.os.dev@gmail.com"
     const val CONTACT_SUBJECT = "User Inquiry or Feedback"
+    const val TERMS_OF_SERVICES_URL = "https://softteco.com/terms-of-services"
 }

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.softteco.template.Constants
+import com.softteco.template.Constants.TERMS_OF_SERVICES_URL
 import com.softteco.template.R
 import com.softteco.template.ui.components.AppLinkText
 import com.softteco.template.ui.components.AppListItem
@@ -38,7 +39,6 @@ import com.softteco.template.ui.theme.ThemeMode
 import com.softteco.template.utils.sendMail
 
 private const val ABOUT_URL = "https://softteco.com"
-private const val TERMS_OF_SERVICES_URL = "https://softteco.com/terms-of-services"
 private const val PRIVACY_POLICY = "https://softteco.com/privacy-policy"
 
 @Composable

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/signUp/SignUpScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/signUp/SignUpScreen.kt
@@ -1,14 +1,18 @@
 package com.softteco.template.ui.feature.signUp
 
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -18,12 +22,15 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.softteco.template.Constants.TERMS_OF_SERVICES_URL
 import com.softteco.template.R
+import com.softteco.template.ui.components.AppLinkText
 import com.softteco.template.ui.components.CustomTopAppBar
 import com.softteco.template.ui.components.EmailField
 import com.softteco.template.ui.components.PasswordField
@@ -63,6 +70,7 @@ private fun ScreenContent(
     onBackClicked: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
+    val context = LocalContext.current
 
     TextSnackbarContainer(
         modifier = modifier,
@@ -110,6 +118,24 @@ private fun ScreenContent(
                         .padding(top = PaddingDefault)
                         .fillMaxWidth()
                 )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Checkbox(
+                        checked = state.termsCheckedStateValue,
+                        onCheckedChange = state.onCheckTermsChange,
+                    )
+                    AppLinkText(
+                        text = stringResource(id = R.string.accept_terms_conditions),
+                        linkText = stringResource(id = R.string.terms_conditions),
+                        linkUrl = TERMS_OF_SERVICES_URL,
+                        openLink = {
+                            val intent = CustomTabsIntent.Builder().build()
+                            intent.launchUrl(context, Uri.parse(it))
+                        }
+                    )
+                }
                 PrimaryButton(
                     buttonText = stringResource(id = R.string.sign_up),
                     loading = state.registrationState == SignUpViewModel.SignupState.Loading,

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModel.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModel.kt
@@ -37,6 +37,7 @@ class SignUpViewModel @Inject constructor(
     private var passwordStateValue = MutableStateFlow("")
     private var snackBarState = MutableStateFlow(SnackBarState())
     private val emailFieldState = MutableStateFlow<EmailFieldState>(EmailFieldState.Empty)
+    private var termsCheckedStateValue = MutableStateFlow(false)
 
     val state = combine(
         registrationState,
@@ -44,8 +45,9 @@ class SignUpViewModel @Inject constructor(
         emailStateValue,
         passwordStateValue,
         snackBarState,
-        emailFieldState
-    ) { registrationState, userName, emailValue, passwordValue, snackBar, emailState ->
+        emailFieldState,
+        termsCheckedStateValue,
+    ) { registrationState, userName, emailValue, passwordValue, snackBar, emailState, termsCheckedState ->
         val passwordState = validatePassword(passwordValue)
         State(
             registrationState = registrationState,
@@ -54,10 +56,12 @@ class SignUpViewModel @Inject constructor(
             passwordValue = passwordValue,
             fieldStateEmail = emailState,
             fieldStatePassword = passwordState,
+            termsCheckedStateValue = termsCheckedState,
             snackBar = snackBar,
             isSignupBtnEnabled = emailState is EmailFieldState.Success &&
                 passwordState is PasswordFieldState.Success &&
-                userName.isNotEmpty(),
+                userName.isNotEmpty() &&
+                termsCheckedState,
             dismissSnackBar = { snackBarState.value = SnackBarState() },
             onUserNameChanged = { userNameStateValue.value = it.trim() },
             onEmailChanged = {
@@ -65,6 +69,7 @@ class SignUpViewModel @Inject constructor(
                 validateEmail(emailStateValue, emailFieldState, viewModelScope, appDispatchers)
             },
             onPasswordChanged = { passwordStateValue.value = it.trim() },
+            onCheckTermsChange = { termsCheckedStateValue.value = it },
             onRegisterClicked = ::onRegister,
         )
     }.stateIn(
@@ -113,6 +118,7 @@ class SignUpViewModel @Inject constructor(
         val userNameValue: String = "",
         val emailValue: String = "",
         val passwordValue: String = "",
+        val termsCheckedStateValue: Boolean = false,
         val fieldStateEmail: EmailFieldState = EmailFieldState.Empty,
         val fieldStatePassword: PasswordFieldState = PasswordFieldState.Empty,
         val isSignupBtnEnabled: Boolean = false,
@@ -120,6 +126,7 @@ class SignUpViewModel @Inject constructor(
         val onEmailChanged: (String) -> Unit = {},
         val onPasswordChanged: (String) -> Unit = {},
         val onRegisterClicked: () -> Unit = {},
+        val onCheckTermsChange: (Boolean) -> Unit = {},
         val dismissSnackBar: () -> Unit = {},
     )
 

--- a/app/src/main/kotlin/com/softteco/template/utils/FlowExtension.kt
+++ b/app/src/main/kotlin/com/softteco/template/utils/FlowExtension.kt
@@ -3,14 +3,15 @@ package com.softteco.template.utils
 import kotlinx.coroutines.flow.Flow
 
 @Suppress("MagicNumber")
-inline fun <T1, T2, T3, T4, T5, T6, R> combine(
+inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,
     flow3: Flow<T3>,
     flow4: Flow<T4>,
     flow5: Flow<T5>,
     flow6: Flow<T6>,
-    crossinline transform: suspend (T1, T2, T3, T4, T5, T6) -> R
+    flow7: Flow<T7>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R
 ): Flow<R> {
     return kotlinx.coroutines.flow.combine(
         flow,
@@ -18,7 +19,8 @@ inline fun <T1, T2, T3, T4, T5, T6, R> combine(
         flow3,
         flow4,
         flow5,
-        flow6
+        flow6,
+        flow7
     ) { args: Array<*> ->
         @Suppress("UNCHECKED_CAST")
         transform(
@@ -27,7 +29,8 @@ inline fun <T1, T2, T3, T4, T5, T6, R> combine(
             args[2] as T3,
             args[3] as T4,
             args[4] as T5,
-            args[5] as T6
+            args[5] as T6,
+            args[6] as T7
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,4 +74,7 @@
     <string name="title_privacy_policy">For further details on how your data is used and stored, please see our\u0020</string>
     <string name="privacy_policy">Privacy Policy</string>
 
+    <!-- Sign up screen -->
+    <string name="accept_terms_conditions">I have read and accept the\u0020</string>
+    <string name="terms_conditions">Terms &amp; Conditions</string>
 </resources>

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/signUp/SignUpViewModelTest.kt
@@ -27,6 +27,8 @@ private const val PASSWORD = "passwordTest"
 private const val INVALID_EMAIL = "invalid@email"
 private const val NEW_PASSWORD_NOT_VALID_1 = "newpassword"
 private const val NEW_PASSWORD_NOT_VALID_2 = "pswD"
+private const val SELECTED_TERMS_CHECKBOX = true
+private const val UNSELECTED_TERMS_CHECKBOX = false
 
 @ExtendWith(MainDispatcherExtension::class)
 class SignUpViewModelTest : BaseTest() {
@@ -51,6 +53,7 @@ class SignUpViewModelTest : BaseTest() {
                 awaitItem().onUserNameChanged(USERNAME)
                 awaitItem().onEmailChanged(EMAIL)
                 awaitItem().onPasswordChanged(PASSWORD)
+                awaitItem().onCheckTermsChange(SELECTED_TERMS_CHECKBOX)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -75,6 +78,7 @@ class SignUpViewModelTest : BaseTest() {
                 awaitItem().onEmailChanged(INVALID_EMAIL)
                 awaitItem().onUserNameChanged(USERNAME)
                 awaitItem().onPasswordChanged(PASSWORD)
+                awaitItem().onCheckTermsChange(SELECTED_TERMS_CHECKBOX)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -92,6 +96,7 @@ class SignUpViewModelTest : BaseTest() {
                 awaitItem().onPasswordChanged(NEW_PASSWORD_NOT_VALID_1)
                 awaitItem().onUserNameChanged(USERNAME)
                 awaitItem().onEmailChanged(EMAIL)
+                awaitItem().onCheckTermsChange(SELECTED_TERMS_CHECKBOX)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -110,6 +115,7 @@ class SignUpViewModelTest : BaseTest() {
                 awaitItem().onPasswordChanged(NEW_PASSWORD_NOT_VALID_2)
                 awaitItem().onUserNameChanged(USERNAME)
                 awaitItem().onEmailChanged(EMAIL)
+                awaitItem().onCheckTermsChange(SELECTED_TERMS_CHECKBOX)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -127,6 +133,7 @@ class SignUpViewModelTest : BaseTest() {
             viewModel.state.test {
                 awaitItem().onPasswordChanged(PASSWORD)
                 awaitItem().onEmailChanged(EMAIL)
+                awaitItem().onCheckTermsChange(SELECTED_TERMS_CHECKBOX)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {
@@ -143,6 +150,23 @@ class SignUpViewModelTest : BaseTest() {
                 awaitItem().run {
                     fieldStatePassword shouldBe PasswordFieldState.Empty
                     fieldStateEmail shouldBe EmailFieldState.Empty
+                    isSignupBtnEnabled shouldBe false
+                }
+            }
+        }
+
+    @Test
+    fun `when checkbox isn't selected and sign-up button isn't enabled`() =
+        runTest {
+            viewModel = SignUpViewModel(repository, userEncryptedDataStore, appDispatchers)
+            viewModel.state.test {
+                awaitItem().onEmailChanged(EMAIL)
+                awaitItem().onUserNameChanged(USERNAME)
+                awaitItem().onPasswordChanged(PASSWORD)
+                awaitItem().onCheckTermsChange(UNSELECTED_TERMS_CHECKBOX)
+                delay(1.seconds)
+
+                expectMostRecentItem().run {
                     isSignupBtnEnabled shouldBe false
                 }
             }
@@ -166,6 +190,7 @@ class SignUpViewModelTest : BaseTest() {
                 awaitItem().onUserNameChanged(USERNAME)
                 awaitItem().onEmailChanged(EMAIL)
                 awaitItem().onPasswordChanged(PASSWORD)
+                awaitItem().onCheckTermsChange(SELECTED_TERMS_CHECKBOX)
                 delay(1.seconds)
 
                 expectMostRecentItem().run {


### PR DESCRIPTION
## Summary

Added the Terms and Conditions tick box on the Sign up screen

## Reasons

User will be able to read the Terms of Service before registration. This will allow user to easily review and understand the terms and conditions of using the app.

## References

closes #119