### PR TITLE
Fix building google-services.json file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,13 +172,14 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
 }
 
 tasks.register("createGoogleServicesJson") {
-    val jsonString = System.getenv("GOOGLE_SERVICES_JSON")
     val isCiBuild = System.getenv("CI")?.toBoolean() ?: false
-    val outputFile = project.file("app/google-services.json")
+    println("isCiBuild: $isCiBuild")
     if (isCiBuild) {
+        val outputFile = project.file("app/google-services.json")
+        val jsonString = System.getenv("GOOGLE_SERVICES_JSON")
         outputFile.writeText(jsonString)
     }
 }
-tasks.build {
+tasks.preBuild {
     dependsOn("createGoogleServicesJson")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,9 +175,11 @@ tasks.register("createGoogleServicesJson") {
     val isCiBuild = System.getenv("CI")?.toBoolean() ?: false
     println("isCiBuild: $isCiBuild")
     if (isCiBuild) {
-        val outputFile = project.file("app/google-services.json")
         val jsonString = System.getenv("GOOGLE_SERVICES_JSON")
-        outputFile.writeText(jsonString)
+        if (jsonString != null) {
+            val outputFile = project.file("app/google-services.json")
+            outputFile.writeText(jsonString)
+        }
     }
 }
 tasks.preBuild {


### PR DESCRIPTION
## Summary

Fix building the google-services.json file on the CI side. 

## Reasons

CI build is crashed at the start, because of the empty google-services.json file.