### PR TITLE
Hide network traffic in release build

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/data/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/softteco/template/data/di/NetworkModule.kt
@@ -26,7 +26,11 @@ object NetworkModule {
     @Provides
     fun provideHTTPLoggingInterceptor(): HttpLoggingInterceptor {
         val interceptor = HttpLoggingInterceptor()
-        interceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
+        if (BuildConfig.DEBUG) {
+            interceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
+        } else {
+            interceptor.setLevel(HttpLoggingInterceptor.Level.NONE)
+        }
         return interceptor
     }
 


### PR DESCRIPTION
## Summary

Hidden network traffic in release build.

## Reasons

Network traffic contains sensitive information such as authentication tokens, API keys, or other credentials. Hiding this information helps prevent unauthorized access and potential security breaches.

## References
 closes #134 