### PR TITLE
Fix the country picker in the profile

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/data/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/softteco/template/data/di/NetworkModule.kt
@@ -23,6 +23,8 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
+    private val json = Json { ignoreUnknownKeys = true }
+
     @Provides
     fun provideHTTPLoggingInterceptor(): HttpLoggingInterceptor {
         val interceptor = HttpLoggingInterceptor()
@@ -59,7 +61,7 @@ object NetworkModule {
 
     @Suppress("SameParameterValue")
     private fun buildRetrofit(okHttpClient: OkHttpClient, baseUrl: String): Retrofit {
-        val converterFactory = Json.asConverterFactory("application/json".toMediaType())
+        val converterFactory = json.asConverterFactory("application/json".toMediaType())
 
         return Retrofit.Builder()
             .baseUrl(baseUrl)

--- a/app/src/main/kotlin/com/softteco/template/data/profile/entity/Profile.kt
+++ b/app/src/main/kotlin/com/softteco/template/data/profile/entity/Profile.kt
@@ -2,9 +2,11 @@ package com.softteco.template.data.profile.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
+@Serializable
 @Entity
 data class Profile(
     @PrimaryKey


### PR DESCRIPTION
## Summary

* Added flag to allow unknown keys during deserialization
* Profile deserialization added

## Reasons

* The RestCountries maintainer changed the schema, or I don't know, but there were fields in there that we didn't need and didn't expect in the current implementation
* There was no deserialization for the Profile model, so an attempt to load Profile data from the cache resulted in a Serialization exception and the data was not displayed on the Profile screen

## References

- closes #149 