### PR TITLE
Fix first launch crash with no internet connection

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/ui/AppContent.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/AppContent.kt
@@ -16,17 +16,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.rememberNavController
-import com.google.firebase.ktx.Firebase
-import com.google.firebase.messaging.ktx.messaging
 import com.softteco.template.navigation.AppBottomBar
 import com.softteco.template.navigation.AppNavHost
 import com.softteco.template.ui.components.RequestNotificationPermissionDialog
 import com.softteco.template.ui.components.dialog.AppDialog
 import com.softteco.template.ui.components.dialog.DialogController
 import com.softteco.template.ui.components.snackbar.SnackbarController
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
-import timber.log.Timber
 
 @Composable
 fun AppContent(
@@ -39,12 +34,6 @@ fun AppContent(
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
-    LaunchedEffect(Unit) {
-        launch {
-            val token = Firebase.messaging.token.await()
-            Timber.tag("FCM token:").d(token)
-        }
-    }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         RequestNotificationPermissionDialog()
     }


### PR DESCRIPTION
## Summary

Simply removed a deprecated FirebaseMessaging initialization call that caused an exception when the Firebase Messaging service was initialized.

## Reasons

Calling the com.google.firebase.messaging.ktx.messaging extension without an internet connection leads to throwing a FirebaseInstallationsException exception. Accessing FirebaseMessaging with this extension is [deprecated](https://firebase.google.com/docs/android/kotlin-migration). In addition, it doesn't do anything other than logging the token.

## References

- closes #156