### PR TITLE
Fix initial navigation in MainActivity

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/MainActivity.kt
+++ b/app/src/main/kotlin/com/softteco/template/MainActivity.kt
@@ -1,55 +1,58 @@
 package com.softteco.template
 
-import android.annotation.SuppressLint
 import android.os.Bundle
+import android.view.View
+import android.view.ViewTreeObserver
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.Composable
+import androidx.activity.viewModels
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import com.softteco.template.data.profile.ProfileRepository
 import com.softteco.template.navigation.Graph
 import com.softteco.template.ui.AppContent
-import com.softteco.template.ui.feature.settings.PreferencesKeys
 import com.softteco.template.ui.theme.AppTheme
-import com.softteco.template.ui.theme.ThemeMode
-import com.softteco.template.utils.SessionManager
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    @Inject
-    lateinit var profileRepository: ProfileRepository
+    val viewModel: MainViewModel by viewModels()
 
-    @Inject
-    lateinit var dataStore: DataStore<Preferences>
-
-    @Inject
-    lateinit var sessionManager: SessionManager
-
-    @SuppressLint("FlowOperatorInvokedInComposition", "CoroutineCreationDuringComposition")
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
+
         setContent {
-            val theme = dataStore.data.map {
-                it[PreferencesKeys.THEME_MODE]
-            }.collectAsState(initial = ThemeMode.SystemDefault.value)
-            val appThemeContent: @Composable () -> Unit = {
-                val isUserLoggedIn by sessionManager.isUserLoggedIn.collectAsState(initial = false)
-                val startDestination =
-                    if (isUserLoggedIn) Graph.BottomBar.route else Graph.Login.route
-                AppContent(startDestination)
+            val isUserLoggedIn by viewModel.isUserLoggedIn.collectAsState()
+            val theme by viewModel.theme.collectAsState()
+
+            // Keep the splash screen on-screen while we check if the user is logged in
+            val content: View = findViewById(android.R.id.content)
+            content.viewTreeObserver.addOnPreDrawListener(
+                object : ViewTreeObserver.OnPreDrawListener {
+                    override fun onPreDraw(): Boolean {
+                        return if (isUserLoggedIn != null) {
+                            content.viewTreeObserver.removeOnPreDrawListener(this)
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                }
+            )
+
+            key(isUserLoggedIn) {
+                AppTheme(theme) {
+                    when (isUserLoggedIn) {
+                        true -> AppContent(Graph.BottomBar.route)
+                        false -> AppContent(Graph.Login.route)
+                        null -> { /*NOOP*/
+                        }
+                    }
+                }
             }
-            theme.value?.let {
-                AppTheme(themeMode = it, content = appThemeContent)
-            } ?: AppTheme(themeMode = ThemeMode.SystemDefault.value, content = appThemeContent)
         }
     }
 }

--- a/app/src/main/kotlin/com/softteco/template/MainViewModel.kt
+++ b/app/src/main/kotlin/com/softteco/template/MainViewModel.kt
@@ -1,0 +1,30 @@
+package com.softteco.template
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.softteco.template.ui.feature.settings.PreferencesKeys
+import com.softteco.template.ui.theme.ThemeMode
+import com.softteco.template.utils.AppDispatchers
+import com.softteco.template.utils.SessionManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    dataStore: DataStore<Preferences>,
+    sessionManager: SessionManager,
+    val appDispatchers: AppDispatchers,
+) : ViewModel() {
+
+    val theme = dataStore.data
+        .map { it[PreferencesKeys.THEME_MODE] ?: ThemeMode.SystemDefault.value }
+        .stateIn(viewModelScope, SharingStarted.Lazily, ThemeMode.SystemDefault.value)
+
+    val isUserLoggedIn = sessionManager.isUserLoggedIn
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+}


### PR DESCRIPTION
## Summary

* Getting the authentication state and topic has been moved to ViewModel;
* Initial state for isUserLoggedIn changed to null. And there is no any composable content for this state;
* The splash screen is removed only when the authentication state is received

## Reasons

The first screen that opens depends on whether the user is logged in or not. We check if there is an authentication token in the DataStore. But we use false as the initial state, so when we create the MainActivity we get false and go to the authorization screen. Then when the token is received, we get true and go to the main screen. And the user sees the login screen for some time, even if the user is already authenticated.

## References

- closes #159 