### PR TITLE
Fix navigation in the password reset flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
             android:name="com.softteco.template.MainActivity"
             android:exported="true"
             android:theme="@style/AppTheme.Splash"
+            android:taskAffinity=""
+            android:allowTaskReparenting="false"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/com/softteco/template/ui/components/AppPasswordField.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/components/AppPasswordField.kt
@@ -90,7 +90,7 @@ fun PasswordField(
         },
         keyboardOptions = KeyboardOptions(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Email,
+            keyboardType = KeyboardType.Password,
         ),
         keyboardActions = KeyboardActions(onDone = {
             keyboardController?.hide()


### PR DESCRIPTION
## Summary

- Added removal of deep link from intent after navigation is executed;
- Changed keyboard type for Password field to avoid autocorrection of inputs.

## Reasons

It looks like the navigation library tries to get a deep link from Intent every time it recomposes NavHost. This results in an unwanted screen opening on the link. Removing the link after creating the navigation graph fixes this problem.

## References

- closes #161 