### PR TITLE
Fix the orientation setting for screens that only support portrait orientation

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/utils/LockScreenOrientation.kt
+++ b/app/src/main/kotlin/com/softteco/template/utils/LockScreenOrientation.kt
@@ -1,5 +1,6 @@
 package com.softteco.template.utils
 
+import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
@@ -7,7 +8,9 @@ import androidx.compose.ui.platform.LocalContext
 @Composable
 fun LockScreenOrientation(orientation: Int) {
     val activity = LocalContext.current.getActivity() ?: return
-    val originalOrientation = activity.resources.configuration.orientation
+    val originalOrientation = activity.resources.configuration.orientation.run {
+        if (this == ORIENTATION_LANDSCAPE) this else activity.requestedOrientation
+    }
 
     DisposableEffect(orientation) {
         activity.requestedOrientation = orientation


### PR DESCRIPTION
## Summary

The original orientation of the activity will now be requested when opening a screen with an orientation from a configuration other than landscape.

## Reasons

For screens that do not support landscape orientation, portrait orientation is forced. But there is a problem in the implementation, and after the first switch to a screen with portrait orientation only, it is fixed permanently for all screens.

## Additional Details

This implementation forces a switch to landscape orientation for a moment on screens that only support portrait orientation. I think since forcing portrait orientation is a temporary solution, we can omit this for now.

## References
- closes #173