### PR TITLE
Add end-to-end tests

### DIFF
--- a/.run/AllTests.run.xml
+++ b/.run/AllTests.run.xml
@@ -1,0 +1,28 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="AllTests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="app:check" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Integration" run_configuration_type="AndroidTestRunConfigurationType" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Unit" run_configuration_type="GradleRunConfiguration" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="E2E" run_configuration_type="JUnit" />
+    </method>
+  </configuration>
+</component>

--- a/.run/E2E.run.xml
+++ b/.run/E2E.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="E2E" type="JUnit" factoryName="JUnit">
+    <module name="Template.app.androidTest" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="ALTERNATIVE_JRE_PATH" value="jbr-17" />
+    <option name="PACKAGE_NAME" value="com.softteco.template" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="pattern" />
+    <option name="TEST_SEARCH_SCOPE">
+      <value defaultName="moduleWithDependencies" />
+    </option>
+    <dir value="./src/androidTest/e2e" />
+    <category value="com.softteco.template.LogInTest" />
+    <patterns>
+      <pattern testClass="com.softteco.template.LogInTest" />
+      <pattern testClass="com.softteco.template.SignUpTest" />
+    </patterns>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Integration.run.xml
+++ b/.run/Integration.run.xml
@@ -1,0 +1,63 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" singleton="true">
+    <module name="Template.app.androidTest" />
+    <option name="TESTING_TYPE" value="0" />
+    <option name="METHOD_NAME" value="" />
+    <option name="CLASS_NAME" value="" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="TEST_NAME_REGEX" value="" />
+    <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />
+    <option name="EXTRA_OPTIONS" value="" />
+    <option name="RETENTION_ENABLED" value="No" />
+    <option name="RETENTION_MAX_SNAPSHOTS" value="2" />
+    <option name="RETENTION_COMPRESS_SNAPSHOTS" value="false" />
+    <option name="CLEAR_LOGCAT" value="false" />
+    <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
+    <option name="TARGET_SELECTION_MODE" value="DEVICE_AND_SNAPSHOT_COMBO_BOX" />
+    <option name="SELECTED_CLOUD_MATRIX_CONFIGURATION_ID" value="-1" />
+    <option name="SELECTED_CLOUD_MATRIX_PROJECT_ID" value="" />
+    <option name="DEBUGGER_TYPE" value="Auto" />
+    <Auto>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Auto>
+    <Hybrid>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Hybrid>
+    <Java>
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Java>
+    <Native>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Native>
+    <Profilers>
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_CPU_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_CPU_PROFILING_CONFIGURATION_NAME" value="Java/Kotlin Method Sample (legacy)" />
+      <option name="STARTUP_NATIVE_MEMORY_PROFILING_ENABLED" value="false" />
+      <option name="NATIVE_MEMORY_SAMPLE_RATE_BYTES" value="2048" />
+    </Profilers>
+    <method v="2">
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Unit.run.xml
+++ b/.run/Unit.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":app:testDebugUnitTest" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -5,19 +5,96 @@
 [![codecov](https://codecov.io/gh/SoftTeco/AndroidAppTemplate/graph/badge.svg)](https://codecov.io/gh/SoftTeco/AndroidAppTemplate)
 ![lint workflow](https://github.com/SoftTeco/AndroidAppTemplate/actions/workflows/lint.yml/badge.svg)
 
-Sample application to demonstrate usage of Jetpack Compose, Kotlin Flow, Android Hilt, etc.
+# E2E Testing with Appium
 
-## Overview
+## Introduction
 
-* Jetpack Compose
-* Compose Navigation
-* Showing Snackbars with Compose
-* Coroutines & Kotlin Flow
-* Android Hilt - for Dependency Injection
-* Unit testing - with Mockito & JUnit
-* Retrofit - for Network Requests
-* Coil - for Image loading
-* Dark & Light Modes
-* Detekt - for checking code style
+**End-to-End (E2E)** testing is a comprehensive testing approach that verifies the functionality of an application from start to finish. E2E tests simulate real user scenarios, ensuring that all integrated components of the application work together as expected. This method provides a high level of confidence in the overall system behavior.
 
-To enable Detekt, execute `pre-commit install` in the terminal from the project root folder.
+### Why is End-to-End Testing cool?
+
+- **Comprehensive Coverage:** E2E tests cover entire user workflows, ensuring that all parts of the application function together as expected.
+- **Integration Validation:** Tests interactions between different components and external interfaces, such as backend services or other apps (e.g., WearOS apps).
+- **Real User Scenarios:** Mimics real user interactions, providing a more realistic assessment of application behavior.
+- **Early Bug Detection:** Identifies issues that unit or integration tests might miss, particularly those arising from interactions between different parts of the application.
+- **Regression Testing:** Facilitates automated regression testing, allowing QA to verify that new code changes do not adversely affect existing functionality. This reduces the need for repetitive manual testing, saving time and effort.
+
+## Appium-Based Automation
+
+Appium is a popular open-source tool for automating mobile and web applications. It enables robust E2E testing by automating user interface interactions.
+
+### Key Components
+
+1. **Appium Server:** Acts as a bridge between your test code and the mobile device/emulator. It receives commands from the test code and executes them on the device.
+2. **Appium Client:** The library used in your test scripts to send commands to the Appium server. It is available for various languages, including Java and Kotlin.
+3. **Emulator or Real Device:** Tests can be run on either an emulator or a physical device. Each test session requires a dedicated instance of the Appium server.
+
+### Getting Started with Appium
+
+To get started with Appium, refer to the [Appium Quickstart Guide](https://appium.io/docs/en/latest/quickstart).
+
+### Test Creation and Execution
+
+1. **Recording Actions with Appium Inspector:**
+    - Appium Inspector helps identify UI elements on the device screen and record user interactions.
+    - You can generate test scripts in various languages and frameworks, such as JUnit4/5 for Java or Kotlin.
+
+2. **Running Tests:**
+    - Ensure the Appium server is running and the device/emulator is connected.
+    - Execute the tests from your IDE or command line.
+
+## Implementation Details
+
+This repository includes several example E2E tests for the **Template** project. These tests demonstrate how to interact with UI elements using **UiAutomator** and **XPath**.
+
+### Example Tests
+
+- **UiAutomator Example:**
+
+  ```kotlin
+  val el3 = findElement(
+      AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.EditText\").instance(0)")
+  )
+  ```
+  
+- **XPath Example:**
+
+  ```kotlin
+  val el4 = findElement(
+      AppiumBy.xpath(
+          "//androidx.compose.ui.platform.ComposeView/android.view.View/android.view.View/android.widget.EditText[1]"
+      )
+  )
+  ```
+  
+### Flaky Tests and Delays
+
+E2E tests can sometimes be flaky due to timing issues or network delays. It's essential to:
+
+- Introduce appropriate waits or retries to handle asynchronous operations.
+- Use explicit waits to wait for elements to be available before interacting with them.
+
+  **Example of a delay for executing a network request:**
+
+  ```kotlin
+  manage().timeouts().implicitlyWait(Duration.ofSeconds(3))
+  ```
+
+## Running E2E Tests
+
+To facilitate running E2E tests alongside unit and integration tests, separate Android Studio run configurations have been created. These configurations ensure that tests can be executed individually or sequentially.
+
+### Run Configurations
+
+- **Unit**: Runs all unit tests.
+- **Integration**: Runs all integration tests.
+- **E2E**: Runs all E2E tests using Appium.
+- **AllTests**: Combines all test types into a single run configuration.
+
+### Executing All Tests
+
+To run all tests sequentially:
+
+1. Open Android Studio.
+2. Select the **AllTests** run configuration.
+3. Click the run button to execute unit, integration, and E2E tests in sequence.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,7 @@ android {
             }
         }
         android.buildFeatures.buildConfig = true
+//        testInstrumentationRunnerArguments["notPackage"] = "src/androidTest/e2e"
     }
 
     buildTypes {
@@ -84,6 +85,11 @@ android {
     testOptions {
         packaging {
             jniLibs { useLegacyPackaging = true }
+        }
+    }
+    sourceSets {
+        getByName("androidTest") {
+            kotlin.srcDirs("src/androidTest/e2e")
         }
     }
 }
@@ -143,6 +149,13 @@ dependencies {
     implementation(libs.play.services.oss.licenses)
 
     testImplementation(libs.junit)
+    testImplementation(libs.org.jetbrains.kotlinx.coroutines.test)
+    testImplementation(libs.org.junit.jupiter.jupiter)
+    testImplementation(libs.org.junit.vintage.engine)
+    testImplementation(libs.io.mockk.mockk)
+    testImplementation(libs.app.cash.turbine)
+    testImplementation(libs.io.kotest.kotest.assertions)
+
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
@@ -150,14 +163,12 @@ dependencies {
     androidTestImplementation(libs.io.mockk.mockk.android)
     androidTestImplementation(libs.io.mockk.mockk.agent)
     androidTestImplementation(libs.org.junit.jupiter.jupiter)
+    androidTestImplementation(libs.io.appium.client)
+    androidTestImplementation(libs.truth)
+
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
-    testImplementation(libs.org.jetbrains.kotlinx.coroutines.test)
-    testImplementation(libs.org.junit.jupiter.jupiter)
-    testImplementation(libs.org.junit.vintage.engine)
-    testImplementation(libs.io.mockk.mockk)
-    testImplementation(libs.app.cash.turbine)
-    testImplementation(libs.io.kotest.kotest.assertions)
+
 }
 
 tasks.withType<Test> {

--- a/app/src/androidTest/e2e/com/softteco/template/LogInTest.kt
+++ b/app/src/androidTest/e2e/com/softteco/template/LogInTest.kt
@@ -1,0 +1,116 @@
+package com.softteco.template
+
+import com.google.common.truth.Truth
+import io.appium.java_client.AppiumBy
+import io.appium.java_client.android.AndroidDriver
+import io.appium.java_client.remote.options.BaseOptions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.URL
+import java.time.Duration
+
+class LogInTest {
+
+    private lateinit var driver: AndroidDriver
+
+    @BeforeEach
+    fun setUp() {
+        val options = BaseOptions()
+            .amend("platformName", "Android")
+            .amend("appium:automationName", "UiAutomator2")
+            .amend("appium:deviceName", "emulator-5554")
+            .amend("udid", "emulator-5554")
+            .amend("appium:appActivity", "com.softteco.template.MainActivity")
+            .amend("appium:appPackage", "com.softteco.template")
+            .amend("appium:ensureWebviewsHavePages", true)
+            .amend("appium:nativeWebScreenshot", true)
+            .amend("appium:connectHardwareKeyboard", true)
+
+        driver = AndroidDriver(URL("http://127.0.0.1:4723"), options)
+    }
+
+    @Test
+    fun when_credentials_correct_then_log_in_succeeded() {
+        driver.run {
+            val el1 = findElement(AppiumBy.className("android.widget.Button"))
+            el1.click()
+
+            val el2 =
+                findElement(AppiumBy.id("com.android.permissioncontroller:id/permission_allow_button"))
+            el2.click()
+
+            val el3 =
+                findElement(
+                    AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.EditText\").instance(0)")
+                )
+            el3.click()
+            el3.sendKeys("automation@gmail.com")
+
+            val el4 =
+                findElement(
+                    AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.EditText\").instance(1)")
+                )
+            el4.click()
+            el4.sendKeys("Automation")
+
+            val el5 =
+                findElement(
+                    AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.Button\").instance(1)")
+                )
+            el5.click()
+
+            manage().timeouts().implicitlyWait(Duration.ofSeconds(3))
+
+            val navBarItem =
+                findElement(AppiumBy.androidUIAutomator("new UiSelector().text(\"Home\")"))
+
+            Truth.assertThat(navBarItem.isDisplayed).isTrue()
+        }
+    }
+
+    @Test
+    fun when_credentials_wrong_then_log_in_failed() {
+        driver.run {
+            val el1 = findElement(AppiumBy.className("android.widget.Button"))
+            el1.click()
+
+            val el2 =
+                findElement(AppiumBy.id("com.android.permissioncontroller:id/permission_allow_button"))
+            el2.click()
+
+            val el3 = findElement(
+                AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.EditText\").instance(0)")
+            )
+            el3.click()
+            el3.sendKeys("automation@gmail.com")
+
+            val el4 = findElement(
+                AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.EditText\").instance(1)")
+            )
+            el4.click()
+            el4.sendKeys("Password")
+
+            val el5 = findElement(
+                AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.Button\").instance(1)")
+            )
+            el5.click()
+
+            manage().timeouts().implicitlyWait(Duration.ofSeconds(3))
+
+            val snackbar =
+                findElement(
+                    AppiumBy.androidUIAutomator(
+                        "new UiSelector().text(\"Incorrect email or password. Please check the data and try again.\")"
+                    )
+                )
+
+            Truth.assertThat(snackbar.isDisplayed).isTrue()
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        driver.quit()
+    }
+}

--- a/app/src/androidTest/e2e/com/softteco/template/SignUpTest.kt
+++ b/app/src/androidTest/e2e/com/softteco/template/SignUpTest.kt
@@ -1,0 +1,98 @@
+@file:Suppress("MaximumLineLength", "MaxLineLength")
+
+package com.softteco.template
+
+import com.google.common.truth.Truth
+import io.appium.java_client.AppiumBy
+import io.appium.java_client.android.AndroidDriver
+import io.appium.java_client.remote.options.BaseOptions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.URL
+import java.time.Duration
+
+class SignUpTest {
+
+    private lateinit var driver: AndroidDriver
+
+    @BeforeEach
+    fun setUp() {
+        val options = BaseOptions().amend("platformName", "Android")
+            .amend("appium:automationName", "UiAutomator2")
+            .amend("appium:deviceName", "emulator-5554").amend("udid", "emulator-5554")
+            .amend("appium:appActivity", "com.softteco.template.MainActivity")
+            .amend("appium:appPackage", "com.softteco.template")
+            .amend("appium:ensureWebviewsHavePages", true).amend("appium:nativeWebScreenshot", true)
+            .amend("appium:connectHardwareKeyboard", true)
+
+        driver = AndroidDriver(URL("http://127.0.0.1:4723"), options)
+    }
+
+    @Test
+    fun when_account_exists_then_sign_up_failed() {
+        driver.run {
+            val el1 = findElement(AppiumBy.className("android.widget.Button"))
+            el1.click()
+
+            val el2 = findElement(
+                AppiumBy.id("com.android.permissioncontroller:id/permission_allow_button")
+            )
+            el2.click()
+
+            val el3 = findElement(
+                AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.Button\").instance(2)")
+            )
+            el3.click()
+
+            val el4 = findElement(
+                AppiumBy.xpath(
+                    "//androidx.compose.ui.platform.ComposeView/android.view.View/android.view.View/android.widget.EditText[1]"
+                )
+            )
+            el4.click()
+            el4.sendKeys("Automation")
+
+            val el5 = findElement(
+                AppiumBy.xpath(
+                    "//androidx.compose.ui.platform.ComposeView/android.view.View/android.view.View/android.widget.EditText[2]"
+                )
+            )
+            el5.click()
+            el5.sendKeys("automation@gmail.com")
+
+            val el6 = findElement(
+                AppiumBy.xpath(
+                    "//androidx.compose.ui.platform.ComposeView/android.view.View/android.view.View/android.widget.EditText[3]"
+                )
+            )
+            el6.click()
+            el6.sendKeys("Automation")
+
+            val el7 = findElement(AppiumBy.className("android.widget.CheckBox"))
+            el7.click()
+
+            driver.executeScript("mobile: pressKey", mapOf("keycode" to 4))
+
+            val el8 = findElement(
+                AppiumBy.androidUIAutomator("new UiSelector().className(\"android.widget.Button\").instance(2)")
+            )
+            el8.click()
+
+            manage().timeouts().implicitlyWait(Duration.ofSeconds(3))
+
+            val snackbar = findElement(
+                AppiumBy.androidUIAutomator(
+                    "new UiSelector().text(\"Username is already taken. Please choose a different username.\")"
+                )
+            )
+
+            Truth.assertThat(snackbar.isDisplayed).isTrue()
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        driver.quit()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,4 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 org.gradle.configuration-cache=true
+android.injected.androidTest.leaveApksInstalledAfterRun = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ minSdk = "26"
 # @keep
 targetSdk = "34"
 
-applicationPlugin = "8.1.1"
+applicationPlugin = "8.2.2"
 ossLicensesPlugin = "0.10.6"
 kotlinAndroidPlugin = "1.9.20"
 ktlinPlugin = "10.2.1"
@@ -26,13 +26,15 @@ composeActivity = "1.8.1"
 composeMaterial3 = "1.1.2"
 splashscreen = "1.0.1"
 junit = "4.13.2"
-junit5 = "5.9.3"
-junit5Plugin = "1.9.3.0"
+junit5 = "5.10.2"
+junit5Plugin = "1.10.0.0"
 kotlinTestCoroutines = "1.7.3"
 testExtJunit = "1.1.5"
 espresso = "3.5.1"
-composeUiTestManifest = "1.5.4"
+composeUiTestManifest = "1.6.8"
+appiumClient = "9.2.3"
 mockk = "1.13.8"
+truth = "1.4.2"
 turbine = "1.0.0"
 kotest = "5.6.2"
 composeDetektRules = "0.0.26"
@@ -112,6 +114,8 @@ google-firebase-messaging = { module = "com.google.firebase:firebase-messaging-k
 google-firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 google-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
+io-appium-client = { module = "io.appium:java-client", version.ref = "appiumClient" }
+truth = { module = "com.google.truth:truth", version.ref = "truth" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "applicationPlugin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Aug 17 12:31:09 MSK 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

- Added End-to-End (E2E) testing capabilities to the Android project using Appium.
- Implemented example E2E tests in the **androidTest/e2e** directory.
- Created Android Studio run configurations for unit, integration, and E2E tests.
- Introduced a combined AllTests run configuration to execute all test types sequentially.

## Reasons

- **E2E Testing Best Practice:** Integrating E2E tests as a best practice to ensure comprehensive testing of the application.
- **Implementation Example:** Providing an example of how to integrate and implement E2E testing within the project.

## References

- closes #176 
- (Appium Quickstart Guide](https://appium.io/docs/en/latest/quickstart)