### PR TITLE
Add support for registration confirmation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,8 @@
 
                 <data android:scheme="https" />
                 <data android:scheme="http" />
-                <data android:host="template.softteco.com.deep_link" />
+                <data android:scheme="tmplt" />
+                <data android:host="template.softteco.com.deep_link"/>
             </intent-filter>
         </activity>
         <service

--- a/app/src/main/kotlin/com/softteco/template/data/base/error/AppError.kt
+++ b/app/src/main/kotlin/com/softteco/template/data/base/error/AppError.kt
@@ -29,6 +29,7 @@ sealed class AppError(val messageRes: Int) {
 
         data object EmailInUse : AuthError("email_in_use", R.string.error_email_already_exists)
         data object EmailNotExist : AuthError("email_not_exist", R.string.error_email_not_found)
+        data object UnconfirmedUser : AuthError("unconfirmed_user", R.string.error_unconfirmed_user)
 
         companion object {
             private fun values() = listOf(
@@ -39,7 +40,8 @@ sealed class AppError(val messageRes: Int) {
                 InvalidToken,
                 UnavailableUsername,
                 EmailInUse,
-                EmailNotExist
+                EmailNotExist,
+                UnconfirmedUser,
             )
 
             fun findByCode(code: String?): AppError {

--- a/app/src/main/kotlin/com/softteco/template/ui/AppContent.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/AppContent.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -16,7 +17,6 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import com.softteco.template.navigation.AppBottomBar
 import com.softteco.template.navigation.AppNavHost
@@ -48,7 +48,7 @@ fun AppContent(
                 AppBottomBar(navController = navController)
             },
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-            contentWindowInsets = WindowInsets(0.dp),
+            contentWindowInsets = WindowInsets.systemBars,
         ) { paddingValues ->
             AppNavHost(
                 navController = navController,

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/onboarding/signup/SignUpViewModel.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/onboarding/signup/SignUpViewModel.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.softteco.template.R
 import com.softteco.template.data.base.error.AppError.AuthError.InvalidEmail
+import com.softteco.template.data.base.error.AppError.AuthError.InvalidUsername
 import com.softteco.template.data.base.error.Result
 import com.softteco.template.data.profile.ProfileRepository
 import com.softteco.template.data.profile.dto.CreateUserDto
 import com.softteco.template.navigation.Screen
 import com.softteco.template.ui.components.FieldState
 import com.softteco.template.ui.components.FieldState.EmailError
+import com.softteco.template.ui.components.FieldState.UsernameError
 import com.softteco.template.ui.components.FieldState.Valid
 import com.softteco.template.ui.components.FieldType
 import com.softteco.template.ui.components.TextFieldState
@@ -115,17 +117,31 @@ class SignUpViewModel @Inject constructor(
 
             when (result) {
                 is Result.Success -> {
-                    snackbarController.showSnackbar(R.string.success)
+                    snackbarController.showSnackbar(R.string.success_signup)
                     _navDestination.tryEmit(Screen.Login)
                 }
 
                 is Result.Error -> {
-                    if (result.error == InvalidEmail) {
-                        usernameState.update {
-                            TextFieldState(
-                                it.text,
-                                EmailError(R.string.email_not_valid)
-                            )
+                    when (result.error) {
+                        InvalidUsername -> {
+                            usernameState.update {
+                                TextFieldState(
+                                    it.text,
+                                    EmailError(R.string.username_not_valid)
+                                )
+                            }
+                        }
+
+                        InvalidEmail -> {
+                            emailState.update {
+                                TextFieldState(
+                                    it.text,
+                                    UsernameError(R.string.email_not_valid)
+                                )
+                            }
+                        }
+
+                        else -> { /*NOOP*/
                         }
                     }
                     snackbarController.showSnackbar(result.error.messageRes)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="error_email_not_found">No user found with this email. Please sign up for an account.</string>
     <string name="error_network">Check your internet connection and try again.</string>
     <string name="error_unknown">Something went wrong. We are already looking into it. Please try again later or contact our support team if the error persists.</string>
+    <string name="error_unconfirmed_user">Your account is not confirmed yet. Please click the link in the confirmation email we sent you.</string>
     <string name="dialog_user_not_found_title">User not found</string>
     <string name="dialog_user_not_found_message">No user with this e-mail address was found. Do you want to register a new account?</string>
 
@@ -66,4 +67,5 @@
     <!-- Sign up screen -->
     <string name="accept_terms_conditions">I have read and accept the\u0020</string>
     <string name="terms_conditions">Terms &amp; Conditions</string>
+    <string name="success_signup">Thank you for signing up! We sent a confirmation email to you.</string>
 </resources>

--- a/app/src/test/kotlin/com/softteco/template/ui/feature/signup/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/softteco/template/ui/feature/signup/SignUpViewModelTest.kt
@@ -70,7 +70,7 @@ class SignUpViewModelTest : BaseTest() {
                     onRegisterClicked()
                 }
 
-                snackbarController.snackbars.value shouldContain SnackbarState(R.string.success)
+                snackbarController.snackbars.value shouldContain SnackbarState(R.string.success_signup)
             }
 
             launch { navDestination.await() shouldBe Screen.Login }


### PR DESCRIPTION
## Summary

- Added support for registration confirmation step (corresponding success and error messages);
- Updated window insets to account for system bars.

## Reasons

- The registration flow now contains a confirmation step. It is necessary to handle errors related to this process and inform the user about sending an e-mail;
- On certain screens, Snackbars were partially obscured by the system panel.

## References

- closes #178
- closes #175
- closes #180 